### PR TITLE
fix: restore compatibility with Antigravity v1.21.6 DOM changes

### DIFF
--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -837,23 +837,38 @@ export class CdpService extends EventEmitter {
     }
 
     /**
-     * Wait by polling until cascade-panel context becomes available.
-     * Right after Antigravity launch, contexts are created asynchronously even after Runtime.enable,
-     * so use this method to confirm readiness before DOM operations.
+     * Wait by polling until the chat panel is ready for DOM operations.
+     * Checks for cascade-panel context (legacy) or #conversation element (1.21.6+).
      *
      * @param timeoutMs Maximum wait time (ms). Default: 10000
      * @param pollIntervalMs Polling interval (ms). Default: 500
-     * @returns true if cascade-panel context was found
+     * @returns true if a usable chat context was found
      */
     async waitForCascadePanelReady(timeoutMs = 10000, pollIntervalMs = 500): Promise<boolean> {
         const start = Date.now();
         while (Date.now() - start < timeoutMs) {
+            // Legacy: cascade-panel context
             const cascadeCtx = this.contexts.find(
                 c => c.url && c.url.includes(SELECTORS.CONTEXT_URL_KEYWORD),
             );
             if (cascadeCtx) {
                 return true;
             }
+
+            // Antigravity 1.21.6+: #conversation element exists in main context
+            // (no separate cascade-panel context is created)
+            try {
+                const res = await this.call('Runtime.evaluate', {
+                    expression: '!!document.getElementById("conversation")',
+                    returnByValue: true,
+                });
+                if (res?.result?.value === true) {
+                    return true;
+                }
+            } catch {
+                // Ignore — may not be connected yet
+            }
+
             await new Promise(r => setTimeout(r, pollIntervalMs));
         }
         return false;
@@ -1494,11 +1509,13 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP.');
         }
 
+        // Antigravity 1.21.6+ uses <button> elements; older versions use <div>.
+        // Use tag-agnostic class-based selector to support both.
         const expression = `(async () => {
-            return Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .map(e => ({text: (e.textContent || '').trim().replace(/New$/, ''), class: e.className}))
-                .filter(e => e.class.includes('px-2 py-1 flex items-center justify-between') || e.text.includes('Gemini') || e.text.includes('GPT') || e.text.includes('Claude'))
-                .map(e => e.text);
+            return Array.from(document.querySelectorAll('button, div'))
+                .filter(e => e.className.includes('px-2 py-1') && e.className.includes('w-full') && e.className.includes('items-center') && e.className.includes('justify-between'))
+                .map(e => (e.textContent || '').trim().replace(/New$/, '').trim())
+                .filter(t => t.length > 0 && t.length < 60);
         })()`;
 
         try {
@@ -1530,10 +1547,11 @@ export class CdpService extends EventEmitter {
         if (!this.isConnectedFlag || !this.ws) {
             return null;
         }
+        // Antigravity 1.21.6+ uses <button> elements; older versions use <div>.
         const expression = `(() => {
-            return Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .find(e => e.className.includes('px-2 py-1 flex items-center justify-between') && e.className.includes('bg-gray-500/20'))
-                ?.textContent?.trim().replace(/New$/, '') || null;
+            var selected = Array.from(document.querySelectorAll('button, div'))
+                .find(e => e.className.includes('px-2 py-1') && e.className.includes('w-full') && e.className.includes('items-center') && e.className.includes('justify-between') && e.className.includes('bg-gray-500/20') && !e.className.includes('hover:bg-gray-500/20'));
+            return selected ? (selected.textContent || '').trim().replace(/New$/, '').trim() : null;
         })()`;
         try {
             const contextId = this.getPrimaryContextId();
@@ -1558,54 +1576,53 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP. Call connect() first.');
         }
 
-        // DOM manipulation script: based on actual Antigravity UI DOM structure
-        // Model list uses div.cursor-pointer elements with class 'px-2 py-1 flex items-center justify-between'
-        // Currently selected has 'bg-gray-500/20', others have 'hover:bg-gray-500/10'
-        // textContent may have "New" suffix
+        // Antigravity 1.21.6+ uses <button> elements; older versions use <div>.
+        // Tag-agnostic class-based selector supports both versions.
+        // textContent may have "New" suffix on newly added models.
         const safeModel = JSON.stringify(modelName);
         const expression = `(async () => {
             const targetModel = ${safeModel};
-            
-            // Get all items in the model list
-            const modelItems = Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .filter(e => e.className.includes('px-2 py-1 flex items-center justify-between'));
-            
+
+            // Get all items in the model list (button in 1.21.6+, div in older)
+            const modelItems = Array.from(document.querySelectorAll('button, div'))
+                .filter(e => e.className.includes('px-2 py-1') && e.className.includes('w-full') && e.className.includes('items-center') && e.className.includes('justify-between'));
+
             if (modelItems.length === 0) {
                 return { ok: false, error: 'Model list not found. The dropdown may not be open.' };
             }
-            
+
             // Match target model by name (compare after removing New suffix)
             const targetItem = modelItems.find(el => {
                 const text = (el.textContent || '').trim().replace(/New$/, '').trim();
                 return text === targetModel || text.toLowerCase() === targetModel.toLowerCase();
             });
-            
+
             if (!targetItem) {
                 const available = modelItems.map(el => (el.textContent || '').trim().replace(/New$/, '').trim()).join(', ');
                 return { ok: false, error: 'Model "' + targetModel + '" not found. Available: ' + available };
             }
-            
+
             // Check if already selected
             if (targetItem.className.includes('bg-gray-500/20') && !targetItem.className.includes('hover:bg-gray-500/20')) {
                 return { ok: true, model: targetModel, alreadySelected: true };
             }
-            
+
             // Click to select model
             targetItem.click();
             await new Promise(r => setTimeout(r, 500));
-            
+
             // Verify selection was applied
-            const updatedItems = Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .filter(e => e.className.includes('px-2 py-1 flex items-center justify-between'));
+            const updatedItems = Array.from(document.querySelectorAll('button, div'))
+                .filter(e => e.className.includes('px-2 py-1') && e.className.includes('w-full') && e.className.includes('items-center') && e.className.includes('justify-between'));
             const selectedItem = updatedItems.find(el => {
                 const text = (el.textContent || '').trim().replace(/New$/, '').trim();
                 return text === targetModel || text.toLowerCase() === targetModel.toLowerCase();
             });
-            
+
             if (selectedItem && selectedItem.className.includes('bg-gray-500/20') && !selectedItem.className.includes('hover:bg-gray-500/20')) {
                 return { ok: true, model: targetModel, verified: true };
             }
-            
+
             // Click succeeded but verification failed
             return { ok: true, model: targetModel, verified: false };
         })()`;

--- a/src/utils/htmlToTelegramMarkdown.ts
+++ b/src/utils/htmlToTelegramMarkdown.ts
@@ -22,12 +22,19 @@ export function htmlToTelegramHtml(html: string): string {
         `\n<b>${stripTags(content).trim()}</b>\n`,
     );
 
-    // Code blocks: <pre><code> (must come before inline code)
+    // Code blocks: <pre><code> (must come before inline code and bare <pre>)
     result = result.replace(
         /<pre[^>]*>\s*<code(?:\s+class="language-([^"]*)")?[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi,
         (_m, lang, content) => lang
             ? `\n<pre><code class="language-${lang}">${content}</code></pre>\n`
             : `\n<pre>${content}</pre>\n`,
+    );
+
+    // Bare <pre> blocks (no <code> child) — e.g. Antigravity renders pipe tables as <pre>
+    // Must come AFTER <pre><code> handling to avoid double-processing
+    result = result.replace(
+        /<pre[^>]*>([\s\S]*?)<\/pre>/gi,
+        (_m, content) => `\n<pre>${content}</pre>\n`,
     );
 
     // Inline code
@@ -180,9 +187,9 @@ export function htmlToTelegramHtml(html: string): string {
     result = result.replace(/<sup[^>]*>([\s\S]*?)<\/sup>/gi, (_m, text) => `^${stripTags(text).trim()}`);
     result = result.replace(/<sub[^>]*>([\s\S]*?)<\/sub>/gi, (_m, text) => `_${stripTags(text).trim()}`);
 
-    // Block-level elements
-    result = result.replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, '$1\n\n');
-    result = result.replace(/<div[^>]*>([\s\S]*?)<\/div>/gi, '$1\n');
+    // Block-level elements — use \b after tag name to prevent <p> matching <pre>, etc.
+    result = result.replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, '$1\n\n');
+    result = result.replace(/<div\b[^>]*>([\s\S]*?)<\/div>/gi, '$1\n');
 
     // Lists (iterative for nested lists)
     for (let iteration = 0; iteration < 5; iteration++) {

--- a/tests/services/cdpService.test.ts
+++ b/tests/services/cdpService.test.ts
@@ -44,17 +44,13 @@ describe('CdpService - Target Detection & Connection', () => {
             ws.on('message', (message) => {
                 const req = JSON.parse(message.toString());
                 if (req.method === 'Runtime.enable') {
-                    // Send mock execution context created
+                    // Send mock execution context created.
+                    // NOTE: Antigravity v1.21.6+ removed the 'cascade-panel' sandboxed context.
+                    // The agent panel now lives directly in the main 'top' workbench context.
                     ws.send(JSON.stringify({
                         method: 'Runtime.executionContextCreated',
                         params: {
                             context: { id: 1, name: 'top', url: 'file:///some/path/workbench.html' }
-                        }
-                    }));
-                    ws.send(JSON.stringify({
-                        method: 'Runtime.executionContextCreated',
-                        params: {
-                            context: { id: 2, name: 'cascade-panel', url: 'file:///some/path/cascade-panel.html' }
                         }
                     }));
                     // Reply to the enable request
@@ -92,7 +88,9 @@ describe('CdpService - Target Detection & Connection', () => {
         expect(targetUrl).toBe(fakeWsUrl);
     });
 
-    it('establishes a WebSocket connection and recognizes the context (cascade-panel)', async () => {
+    it('establishes a WebSocket connection and uses the top-level workbench context (v1.21.6+)', async () => {
+        // Antigravity v1.21.6 removed the cascade-panel sandboxed context.
+        // The bot now operates in the main workbench 'top' context (id 1).
         await service.connect();
         expect(service.isConnected()).toBe(true);
 
@@ -103,7 +101,7 @@ describe('CdpService - Target Detection & Connection', () => {
         expect(contexts.length).toBeGreaterThanOrEqual(1);
 
         const targetContextId = service.getPrimaryContextId();
-        expect(targetContextId).toBe(2); // cascade-panel.html is id 2
+        expect(targetContextId).toBe(1); // top workbench context
     });
 
     it('triggers the auto-reconnect listener when disconnected', async () => {

--- a/tests/utils/htmlToTelegramMarkdown.test.ts
+++ b/tests/utils/htmlToTelegramMarkdown.test.ts
@@ -77,6 +77,51 @@ describe('htmlToTelegramHtml', () => {
         });
     });
 
+    // Regression tests for Antigravity v1.21.6 compatibility
+    // Antigravity renders markdown pipe tables as bare <pre>text</pre> blocks.
+    // Two bugs combined to produce an orphan </pre> tag that caused Telegram
+    // 400 "Unexpected end tag" errors.
+    describe('bare <pre> blocks (Antigravity v1.21.6 regression)', () => {
+        it('bare <pre> block produces matched opening and closing tags', () => {
+            // Bug: <pre><code> handler skipped bare <pre>; stripUnsupportedTags
+            // stripped the <pre> open but kept </pre>, causing a Telegram 400.
+            const html = '<pre>| Layer | What it does |\n|---|---|\n| Bot | UI |</pre>';
+            const result = htmlToTelegramHtml(html);
+            const opens = (result.match(/<pre>/gi) ?? []).length;
+            const closes = (result.match(/<\/pre>/gi) ?? []).length;
+            expect(opens).toBe(closes);
+            expect(opens).toBeGreaterThanOrEqual(1);
+            expect(result).toContain('| Layer |');
+        });
+
+        it('<p> regex does not consume adjacent <pre> tags', () => {
+            // Bug: <p[^>]*> matched <pre> (reads as <p + re + >) so the paragraph
+            // replacement ate the <pre> opening tag, leaving an orphan </pre>.
+            const html = '<p>Intro text.</p><pre>| A | B |\n| C | D |</pre><p>After text.</p>';
+            const result = htmlToTelegramHtml(html);
+            const opens = (result.match(/<pre>/gi) ?? []).length;
+            const closes = (result.match(/<\/pre>/gi) ?? []).length;
+            expect(opens).toBe(closes);
+            expect(result).toContain('Intro text.');
+            expect(result).toContain('| A | B |');
+            expect(result).toContain('After text.');
+        });
+
+        it('multiple bare <pre> blocks all have matched tags', () => {
+            // Simulates the real failing case: a table <pre> followed by a code-flow <pre>.
+            const html =
+                '<p>Here is a table:</p>' +
+                '<pre>| Layer | What it does |\n|---|---|\n| Bot | UI |</pre>' +
+                '<p>And the flow:</p>' +
+                '<pre>Telegram → router\n  └── text → agent</pre>';
+            const result = htmlToTelegramHtml(html);
+            const opens = (result.match(/<pre>/gi) ?? []).length;
+            const closes = (result.match(/<\/pre>/gi) ?? []).length;
+            expect(opens).toBe(closes);
+            expect(opens).toBe(2);
+        });
+    });
+
     describe('links', () => {
         it('preserves link tags with href', () => {
             const html = '<a href="https://example.com">click here</a>';


### PR DESCRIPTION
## Summary

Restores full Remoat compatibility with Antigravity IDE v1.21.6, which shipped a visual redesign of the agent panel that changed the DOM in three ways, breaking the bot.

## Related Issues

Closes # <!-- link issue if one exists -->

## Type of Change

- [x] Bug fix

## What Changed

### 1. Model picker — `<div>` → `<button>` (`cdpService.ts`)

Antigravity v1.21.6 changed model dropdown items from `<div class="cursor-pointer">` to `<button>` elements and added a `w-full` class. The old selectors found nothing, making `/model` return an empty list.

**Fix:** Switched `getUiModels()`, `getCurrentModel()`, and `setUiModel()` to tag-agnostic `:is(button, div)` selectors with `w-full` scoping to work across both old and new markup.

### 2. Context readiness — `cascade-panel` context removed (`cdpService.ts`)

`waitForCascadePanelReady()` polled for a CDP execution context named `cascade-panel` (a sandboxed iframe Antigravity used for the agent panel). That context was removed in v1.21.6 — the panel now renders directly in the main workbench context. The bot would hang forever waiting for a context that no longer exists.

**Fix:** Updated the readiness check to query the main workbench DOM for `#conversation` instead.

### 3. Telegram 400 parse error — orphan `</pre>` tag (`htmlToTelegramMarkdown.ts`)

Antigravity renders markdown pipe tables as bare `<pre>raw text</pre>` blocks (not `<pre><code>`). Two bugs in the HTML formatter combined to produce an orphan `</pre>` closing tag, causing Telegram to reject messages with `400 Bad Request: Unexpected end tag`:

- **Missing bare `<pre>` handler** — only `<pre><code>` pairs were handled. Bare `<pre>` blocks fell through; `stripUnsupportedTags` stripped the opening `<pre>` but kept `</pre>`.
- **`<p[^>]*>` regex matched `<pre>` tags** — `<p` + `[^>]*` matches `re` + `>`, making `<pre>` look like `<p re>`. The paragraph replacement ate the `<pre>` opening tag.

**Fix:** Added an explicit bare `<pre>` handler (runs after `<pre><code>`). Added `\b` word boundary to the `<p>` and `<div>` block-level regexes.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the diff
- [x] Added/updated tests (`tests/utils/htmlToTelegramMarkdown.test.ts`, `tests/services/cdpService.test.ts`)
- [x] `npm test` and `npm run build` pass locally — 704/704 tests passing
- [x] Updated relevant documentation (if applicable)
