### PR TITLE
fix: walkthrough artifact detection and UI flow

### DIFF
--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -179,7 +179,7 @@ Open button (with optional Proceed button) for plan and artifact review.
 
 ### Detection
 
-**Crucial Note:** To prevent erroneously detecting older planning cards when a user scrolls up or when buttons resolve slowly, all artifact card searches must be scoped strictly to the latest message container (`[data-message-author-role="assistant"]`).
+**Crucial Note:** The assistant container `[data-message-author-role="assistant"]` does NOT exist in Antigravity. To prevent erroneously detecting older planning cards or infinite "Planning dialog active" deferral loops, all artifact card searches must be positionally scoped to follow the last user message using `Node.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING` (value 4). Furthermore, you must **reverse-iterate** over found artifact cards to interact with the newest one first.
 
 | Selector | Purpose | File |
 |----------|---------|------|

--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -179,9 +179,13 @@ Open button (with optional Proceed button) for plan and artifact review.
 
 ### Detection
 
+**Crucial Note:** To prevent erroneously detecting older planning cards when a user scrolls up or when buttons resolve slowly, all artifact card searches must be scoped strictly to the latest message container (`[data-message-author-role="assistant"]`).
+
 | Selector | Purpose | File |
 |----------|---------|------|
-| `.notify-user-container` | Planning notification container | `planningDetector.ts` |
+| `.notify-user-container` (last in DOM, or within latest msg) | Planning notification container | `planningDetector.ts` |
+| `div[class*="border"][class*="rounded-lg"]` (within latest msg) | Fallback card container for artifact chips | `planningDetector.ts` |
+| `span[class*="inline-flex"][class*="cursor-pointer"]` | Clickable artifact chip (for auto-expansion if buttons are hidden) | `planningDetector.ts` |
 | `span.inline-flex.break-all` | Plan title (file name) | `planningDetector.ts` |
 | `span.text-sm` | Plan summary text | `planningDetector.ts` |
 | `.leading-relaxed.select-text` | Plan description body | `planningDetector.ts` |

--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -173,9 +173,9 @@ Tool permission dialog (Allow/Deny).
 
 ---
 
-## 8. Planning Mode
+## 8. Planning Mode / Artifact Cards
 
-Open/Proceed button pair for plan review.
+Open button (with optional Proceed button) for plan and artifact review.
 
 ### Detection
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoat",
-  "version": "0.2.8",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remoat",
-      "version": "0.2.8",
+      "version": "0.2.13",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -174,14 +174,27 @@ async function sendPromptToAntigravity(
         }
     };
 
-    const editMsg = async (msgId: number, text: string): Promise<void> => {
-        try {
-            const truncated = text.length > TELEGRAM_MSG_LIMIT ? text.slice(0, TELEGRAM_MSG_LIMIT - 20) + '\n...(truncated)' : text;
-            await api.editMessageText(channel.chatId, msgId, truncated, { parse_mode: 'HTML' });
-        } catch (e: any) {
-            const desc = e?.description || e?.message || '';
-            if (!desc.includes('message is not modified')) {
+    const editMsg = async (msgId: number, text: string, maxRetries = 3): Promise<void> => {
+        const truncated = text.length > TELEGRAM_MSG_LIMIT ? text.slice(0, TELEGRAM_MSG_LIMIT - 20) + '\n...(truncated)' : text;
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                await api.editMessageText(channel.chatId, msgId, truncated, { parse_mode: 'HTML' });
+                break;
+            } catch (e: any) {
+                const desc = e?.description || e?.message || '';
+                if (desc.includes('message is not modified')) {
+                    break;
+                }
+                const retryAfter = e?.parameters?.retry_after;
+                if (retryAfter) {
+                    logger.error(`[editMsg] Too Many Requests: retry after ${retryAfter}s (attempt ${attempt}/${maxRetries})`);
+                    if (attempt < maxRetries) {
+                        await new Promise(r => setTimeout(r, retryAfter * 1000));
+                        continue;
+                    }
+                }
                 logger.error('[editMsg] Failed:', desc);
+                break;
             }
         }
     };
@@ -457,11 +470,28 @@ async function sendPromptToAntigravity(
         const progressTitle = () => `${PHASE_ICONS.thinking} ${modelLabel}`;
         const progressFooter = () => `⏱️ ${Math.round((Date.now() - startTime) / 1000)}s`;
 
+        let lastProgressTrigger = 0;
+        let progressTriggerTimeout: NodeJS.Timeout | null = null;
+
         /** Trigger a progress message refresh */
         const triggerProgressRefresh = (): void => {
-            liveActivityUpdateVersion += 1;
-            const v = liveActivityUpdateVersion;
-            refreshProgress(progressTitle(), progressFooter(), { expectedVersion: v, skipWhenFinalized: true }).catch(() => { });
+            const now = Date.now();
+            if (now - lastProgressTrigger >= 3000) {
+                if (progressTriggerTimeout) { clearTimeout(progressTriggerTimeout); progressTriggerTimeout = null; }
+                lastProgressTrigger = now;
+                liveActivityUpdateVersion += 1;
+                const v = liveActivityUpdateVersion;
+                refreshProgress(progressTitle(), progressFooter(), { expectedVersion: v, skipWhenFinalized: true }).catch(() => { });
+            } else if (!progressTriggerTimeout) {
+                progressTriggerTimeout = setTimeout(() => {
+                    progressTriggerTimeout = null;
+                    if (isFinalized) return;
+                    lastProgressTrigger = Date.now();
+                    liveActivityUpdateVersion += 1;
+                    const v = liveActivityUpdateVersion;
+                    refreshProgress(progressTitle(), progressFooter(), { expectedVersion: v, skipWhenFinalized: true }).catch(() => { });
+                }, 3000 - (now - lastProgressTrigger));
+            }
         };
 
         await refreshProgress(progressTitle(), progressFooter());
@@ -1393,7 +1423,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                         const pages = paginatePlanContent(planContent);
                         planContentCache.set(chKey, pages);
                         const targetChannelStr = ch.threadId ? String(ch.threadId) : String(ch.chatId);
-                        const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, 0, projectName || '', targetChannelStr);
+                        const lastInfo = detector.getLastDetectedInfo();
+                        const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, 0, projectName || '', targetChannelStr, lastInfo?.planTitle ?? undefined, lastInfo?.proceedText ?? undefined);
                         await bot.api.sendMessage(ch.chatId, pageText, { parse_mode: 'HTML', message_thread_id: ch.threadId, reply_markup: pageKeyboard });
                     }
                 }
@@ -1427,8 +1458,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     const pages = paginatePlanContent(planContent);
                     planContentCache.set(chKey, pages);
                     const targetChannelStr = ch.threadId ? String(ch.threadId) : String(ch.chatId);
-                    const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, 0, projectName, targetChannelStr);
+                    const lastInfo = detector.getLastDetectedInfo();
+                    const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, 0, projectName, targetChannelStr, lastInfo?.planTitle ?? undefined, lastInfo?.proceedText ?? undefined);
                     await bot.api.sendMessage(ch.chatId, pageText, { parse_mode: 'HTML', message_thread_id: ch.threadId, reply_markup: pageKeyboard });
+                } else {
+                    await bot.api.sendMessage(ch.chatId, `\u26A0\uFE0F <b>Extraction Failed</b>\n\nThe ${projectName ? escapeHtml(projectName) : 'workspace'} UI was instructed to open the file, but we couldn't extract the text content to show inside Telegram. Please check your IDE.`, { parse_mode: 'HTML', message_thread_id: ch.threadId });
                 }
             }
             await ctx.answerCallbackQuery({ text: clicked ? 'Opened' : 'Open button not found.' });
@@ -1485,7 +1519,10 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const pages = planContentCache.get(chKey);
             if (!pages || isNaN(page)) { await ctx.answerCallbackQuery({ text: 'Page not found.' }); return; }
 
-            const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, page, projectName, targetChannelStr || String(ch.chatId));
+            const detector = projectName ? bridge.pool.getPlanningDetector(projectName) : undefined;
+            const lastInfo = detector?.getLastDetectedInfo();
+
+            const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, page, projectName, targetChannelStr || String(ch.chatId), lastInfo?.planTitle ?? undefined, lastInfo?.proceedText ?? undefined);
             try { await ctx.editMessageText(pageText, { parse_mode: 'HTML', reply_markup: pageKeyboard }); } catch { }
             await ctx.answerCallbackQuery({ text: `Page ${page + 1}/${pages.length}` });
             return;

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -449,6 +449,19 @@ async function sendPromptToAntigravity(
     let monitor: ResponseMonitor | null = null;
 
     try {
+        // Reset PlanningDetector baseline BEFORE injecting the message.
+        // This snapshots the current artifact count so the detector only
+        // fires on NEW artifacts from the upcoming response (not old session artifacts).
+        const projectName = cdp.getCurrentWorkspaceName() || bridge.lastActiveWorkspace;
+        if (projectName) {
+            const detector = bridge.pool.getPlanningDetector(projectName);
+            if (detector) {
+                await detector.resetBaseline().catch((err: Error) =>
+                    logger.error('[sendPrompt] PlanningDetector baseline reset failed:', err),
+                );
+            }
+        }
+
         let injectResult;
         if (inboundImages.length > 0) {
             injectResult = await cdp.injectMessageWithImageFiles(prompt, inboundImages.map(i => i.localPath));

--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -282,6 +282,107 @@ export function extractAssistantSegmentsPayloadScript(): string {
         }
     }
 
+    // Pass 1.5: Extract artifact cards (planning cards, etc.) from chat
+    var artifactCards = [];
+    var OPEN_PATS_15 = ['open', 'view'];
+    var PROCEED_PATS_15 = ['proceed', 'accept', 'approve'];
+    var btnNorm15 = function(b) { return (b.textContent || '').toLowerCase().replace(/\s+/g, ' ').trim(); };
+    var allBtns = Array.from(scope.querySelectorAll('button')).filter(function(b) { return b.offsetParent !== null; });
+    var openBtn = allBtns.find(function(b) { var t = btnNorm15(b); return OPEN_PATS_15.some(function(p) { return t === p || t.includes(p); }); });
+    var proceedBtn = allBtns.find(function(b) { var t = btnNorm15(b); return PROCEED_PATS_15.some(function(p) { return t === p || t.includes(p); }); });
+    
+    if (openBtn) {
+        var p = openBtn.parentElement;
+        // If both buttons exist, walk up from proceedBtn to their common ancestor
+        if (proceedBtn) {
+            p = proceedBtn.parentElement;
+            while (p && p !== scope && !p.contains(openBtn)) { p = p.parentElement; }
+        }
+        if (p) {
+            var card = p.closest && p.closest('[class*="border"][class*="rounded"]');
+            if (!card) card = p.parentElement && p.parentElement.parentElement;
+            if (card) artifactCards.push(card);
+        }
+    }
+    
+    var notifyCards = Array.from(scope.querySelectorAll('.notify-user-container'));
+    for (var ni = 0; ni < notifyCards.length; ni++) {
+        if (!artifactCards.includes(notifyCards[ni])) artifactCards.push(notifyCards[ni]);
+    }
+
+    for (var ci = 0; ci < artifactCards.length; ci++) {
+        var card = artifactCards[ci];
+        var mdNodes = Array.from(card.querySelectorAll('.rendered-markdown, .markdown-body, .prose'));
+        if (mdNodes.length === 0) {
+            mdNodes = [card];
+        }
+        for (var mi = 0; mi < mdNodes.length; mi++) {
+            var mdNode = mdNodes[mi];
+            var clone = mdNode.cloneNode(true);
+            
+            var cardBtns = clone.querySelectorAll('button');
+            for(var b=0; b<cardBtns.length; b++) cardBtns[b].parentNode.removeChild(cardBtns[b]);
+            
+            var pres = clone.querySelectorAll('pre');
+            for (var pi = 0; pi < pres.length; pi++) {
+                var pre = pres[pi];
+                var langDiv = pre.querySelector('.font-sans.text-sm, [class*="text-sm"][class*="opacity"]');
+                var lang = langDiv ? (langDiv.textContent || '').trim() : '';
+
+                var styles = pre.querySelectorAll('style');
+                for (var si = 0; si < styles.length; si++) {
+                    styles[si].parentNode.removeChild(styles[si]);
+                }
+
+                var headerBar = pre.querySelector('[class*="rounded-t"][class*="border-b"]');
+                if (headerBar) headerBar.parentNode.removeChild(headerBar);
+
+                var codeLines = pre.querySelectorAll('.code-line, [class*="code-line"]');
+                var codeText;
+                if (codeLines.length > 0) {
+                    var lineTexts = [];
+                    for (var cli = 0; cli < codeLines.length; cli++) {
+                        lineTexts.push(codeLines[cli].textContent || '');
+                    }
+                    codeText = lineTexts.join('\\n');
+                } else {
+                    codeText = (pre.innerText || '').trim();
+                    if (lang && codeText.startsWith(lang)) {
+                        codeText = codeText.slice(lang.length).trim();
+                    }
+                }
+                codeText = codeText.replace(/\\nCopy$/i, '').replace(/\\ncopy code$/i, '').trim();
+                
+                var newPre = document.createElement('pre');
+                var newCode = document.createElement('code');
+                if (lang) newCode.setAttribute('class', 'language-' + lang);
+                newCode.textContent = codeText;
+                newPre.appendChild(newCode);
+                pre.parentNode.replaceChild(newPre, pre);
+            }
+            
+            var topStyles = clone.querySelectorAll('style, script');
+            for (var tsi = 0; tsi < topStyles.length; tsi++) {
+                topStyles[tsi].parentNode.removeChild(topStyles[tsi]);
+            }
+            
+            var artifactHtml = clone.innerHTML;
+            if (artifactHtml && artifactHtml.trim()) {
+                if (mdNodes[0] === card) {
+                    artifactHtml = '<div>' + artifactHtml + '</div>';
+                }
+                segments.push({
+                    kind: 'assistant-body',
+                    text: artifactHtml,
+                    role: 'assistant',
+                    messageIndex: 0,
+                    domPath: 'artifact-card'
+                });
+                bodyFound = true;
+            }
+        }
+    }
+
     // Pass 2: Extract thinking + tool segments from <details>
     var details = scope.querySelectorAll('details');
     for (var di = 0; di < details.length; di++) {

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -356,6 +356,17 @@ export function ensurePlanningDetector(
                 lastMessageChatId = targetChannel.chatId;
             }
         },
+        onAutoOpened: async (chipText: string) => {
+            logger.info(`[PlanningDetector:${projectName}] Auto-opened: "${chipText}"`);
+
+            const currentChatTitle = await getCurrentChatTitle(cdp);
+            const targetChannel = resolveApprovalChannelForCurrentChat(bridge, projectName, currentChatTitle);
+
+            if (!targetChannel || !bridge.botApi) return;
+
+            const text = `📄 <b>${chipText}</b> opened in <b>${projectName}</b>\n\n<i>Auto-opened — view in Antigravity editor.</i>`;
+            await sendTelegramMessage(bridge.botApi, targetChannel, text);
+        },
     });
 
     detector.start();

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -261,10 +261,11 @@ export class CdpService extends EventEmitter {
 
     async disconnect(): Promise<void> {
         this.stopHeartbeat();
-        // Suppress reconnection during intentional disconnect
-        const savedMaxReconnectAttempts = this.maxReconnectAttempts;
-        this.maxReconnectAttempts = 0;
+        // Suppress 'disconnected' event (and reconnect attempts) during intentional shutdown
+        const prev = this.isSwitchingWorkspace;
+        this.isSwitchingWorkspace = true;
         if (this.ws) {
+            this.ws.removeAllListeners();
             this.ws.close();
             this.ws = null;
         }
@@ -273,8 +274,7 @@ export class CdpService extends EventEmitter {
         this.currentWorkspacePath = null;
         this.currentWorkspaceName = null;
         this.clearPendingCalls(new Error('disconnect() was called'));
-        // Restore so future connect() calls can still reconnect
-        this.maxReconnectAttempts = savedMaxReconnectAttempts;
+        this.isSwitchingWorkspace = prev;
     }
 
     /**

--- a/src/services/planningDetector.ts
+++ b/src/services/planningDetector.ts
@@ -7,7 +7,7 @@ export interface PlanningInfo {
     /** Open button text */
     openText: string;
     /** Proceed button text */
-    proceedText: string;
+    proceedText: string | null;
     /** Plan title (file name shown in the card) */
     planTitle: string;
     /** Plan summary text */
@@ -34,8 +34,8 @@ export interface PlanningDetectorOptions {
  * and extracts plan metadata from the surrounding DOM elements.
  */
 const DETECT_PLANNING_SCRIPT = `(() => {
-    const OPEN_PATTERNS = ['open'];
-    const PROCEED_PATTERNS = ['proceed'];
+    const OPEN_PATTERNS = ['open', 'view'];
+    const PROCEED_PATTERNS = ['proceed', 'accept', 'approve'];
 
     const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
 
@@ -56,21 +56,27 @@ const DETECT_PLANNING_SCRIPT = `(() => {
         return PROCEED_PATTERNS.some(p => t === p || t.includes(p));
     }) || null;
 
-    // Both buttons must exist for this to be a planning UI
-    if (!openBtn || !proceedBtn) return null;
+    // An Open button must exist for this to be recognized as an artifact card
+    if (!openBtn) return null;
 
     const openText = (openBtn.textContent || '').trim();
-    const proceedText = (proceedBtn.textContent || '').trim();
+    const proceedText = proceedBtn ? (proceedBtn.textContent || '').trim() : null;
 
-    // Extract plan title from .inline-flex.break-all
-    const titleEl = container.querySelector('span.inline-flex.break-all, .inline-flex.break-all');
-    const planTitle = titleEl ? (titleEl.textContent || '').trim() : '';
+    // Extract plan title from .inline-flex.break-all or .font-mono
+    const titleEl = container.querySelector('span.inline-flex.break-all, .inline-flex.break-all, .font-mono.text-sm.truncate, .font-mono.truncate');
+    let planTitle = titleEl ? (titleEl.textContent || '').trim() : '';
+
+    if (!planTitle && openText) {
+        // Fallback: extract from open button text (e.g., "Open task.md" -> "task.md")
+        const match = openText.match(/open\\s+(.*)/i);
+        if (match) planTitle = match[1].trim();
+    }
 
     // Extract plan summary from span.text-sm (excluding buttons text)
     const summaryEls = Array.from(container.querySelectorAll('span.text-sm'));
     const planSummary = summaryEls
         .map(el => (el.textContent || '').trim())
-        .filter(text => text.length > 0 && text !== openText && text !== proceedText)
+        .filter(text => text.length > 0 && text !== openText && text !== proceedText && text !== planTitle)
         .join(' ');
 
     // Extract description from leading-relaxed container, skipping code/style blocks
@@ -151,7 +157,16 @@ const EXTRACT_PLAN_CONTENT_SCRIPT = `(() => {
         }
     }
 
-    // Fallback: any leading-relaxed.select-text with significant content
+    // Fallback 1: Common markdown container classes
+    const mdContainers = Array.from(document.querySelectorAll(
+        '[data-testid="markdown-content"], .markdown-body, .prose'
+    ));
+    for (const container of mdContainers) {
+        const md = htmlToMd(container);
+        if (md.length > 50) return md;
+    }
+
+    // Fallback 2: any leading-relaxed.select-text with significant content
     const allLeading = Array.from(document.querySelectorAll('.leading-relaxed.select-text'));
     for (const el of allLeading) {
         const md = htmlToMd(el);

--- a/src/services/planningDetector.ts
+++ b/src/services/planningDetector.ts
@@ -33,31 +33,67 @@ export interface PlanningDetectorOptions {
  * Looks for Open/Proceed button pairs inside .notify-user-container
  * and extracts plan metadata from the surrounding DOM elements.
  */
-const DETECT_PLANNING_SCRIPT = `(() => {
+const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
     const OPEN_PATTERNS = ['open', 'view'];
     const PROCEED_PATTERNS = ['proceed', 'accept', 'approve'];
+    const lastClickedText = ${lastClickedText ? JSON.stringify(lastClickedText) : 'null'};
 
     const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
 
-    // Find the notify container that holds planning UI
-    const container = document.querySelector('.notify-user-container');
-    if (!container) return null;
+    // Scope to the latest assistant message to avoid detecting old plans
+    const messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
+    const latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
 
-    const allButtons = Array.from(container.querySelectorAll('button'))
-        .filter(btn => btn.offsetParent !== null);
+    // Find the notify container that holds planning UI - prefer the last one
+    const containers = Array.from(document.querySelectorAll('.notify-user-container'));
+    let container = containers.length > 0 ? containers[containers.length - 1] : null;
+    let openBtn = null;
+    let proceedBtn = null;
 
-    const openBtn = allButtons.find(btn => {
-        const t = normalize(btn.textContent || '');
-        return OPEN_PATTERNS.some(p => t === p || t.includes(p));
-    }) || null;
+    if (container) {
+        const allButtons = Array.from(container.querySelectorAll('button')).filter(btn => btn.offsetParent !== null);
+        openBtn = allButtons.find(btn => { const t = normalize(btn.textContent); return OPEN_PATTERNS.some(p => t === p || t.includes(p)); });
+        proceedBtn = allButtons.find(btn => { const t = normalize(btn.textContent); return PROCEED_PATTERNS.some(p => t === p || t.includes(p)); });
+    } else {
+        const docBtns = Array.from(latestMsg.querySelectorAll('button')).filter(btn => btn.offsetParent !== null);
+        openBtn = docBtns.find(btn => { const t = normalize(btn.textContent); return OPEN_PATTERNS.some(p => t === p || t.includes(p)); });
+        proceedBtn = docBtns.find(btn => { const t = normalize(btn.textContent); return PROCEED_PATTERNS.some(p => t === p || t.includes(p)); });
+        
+        if (openBtn) {
+            let p = openBtn.parentElement;
+            if (proceedBtn) {
+                p = proceedBtn.parentElement;
+                while (p && p !== document.body && !p.contains(openBtn)) { p = p.parentElement; }
+            }
+            if (p) {
+                container = p.closest('[class*="border"][class*="rounded"]');
+                if (!container) container = p.parentElement ? p.parentElement.parentElement : null;
+            }
+        }
+    }
 
-    const proceedBtn = allButtons.find(btn => {
-        const t = normalize(btn.textContent || '');
-        return PROCEED_PATTERNS.some(p => t === p || t.includes(p));
-    }) || null;
-
-    // An Open button must exist for this to be recognized as an artifact card
-    if (!openBtn) return null;
+    // Fallback: Check for collapsed artifact cards in the latest message
+    if (!openBtn || !container) {
+        const cards = Array.from(latestMsg.querySelectorAll('div[class*="border"][class*="rounded-lg"]'));
+        for (const card of cards) {
+            const chip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
+            if (chip && card.offsetParent !== null) {
+                const text = (chip.textContent || '').trim();
+                const buttons = Array.from(card.querySelectorAll('button'));
+                const hasOpenOrProceed = buttons.some(btn => {
+                    const t = normalize(btn.textContent);
+                    return OPEN_PATTERNS.some(p => t === p || t.includes(p)) || t.includes('proceed');
+                });
+                if (!hasOpenOrProceed) {
+                    if (text && text !== lastClickedText) {
+                        chip.click();
+                        return { collapsed: true, chipText: text };
+                    }
+                }
+            }
+        }
+        return null; // Both failed
+    }
 
     const openText = (openBtn.textContent || '').trim();
     const proceedText = proceedBtn ? (proceedBtn.textContent || '').trim() : null;
@@ -202,6 +238,9 @@ export class PlanningDetector {
     private lastNotifiedAt: number = 0;
     /** Cooldown period in ms to suppress duplicate notifications */
     private static readonly COOLDOWN_MS = 5000;
+    
+    /** Click-guard state to prevent infinite auto-click loops on collapsed cards */
+    private lastClickedChip: { text: string; at: number } | null = null;
 
     constructor(options: PlanningDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -217,12 +256,14 @@ export class PlanningDetector {
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
         this.lastNotifiedAt = 0;
+        this.lastClickedChip = null;
         this.schedulePoll();
     }
 
     /** Stop monitoring. */
     async stop(): Promise<void> {
         this.isRunning = false;
+        this.lastClickedChip = null;
         if (this.pollTimer) {
             clearTimeout(this.pollTimer);
             this.pollTimer = null;
@@ -292,9 +333,14 @@ export class PlanningDetector {
      */
     private async poll(): Promise<void> {
         try {
+            // Expire click-guard state after 10 seconds
+            if (this.lastClickedChip && Date.now() - this.lastClickedChip.at > 10000) {
+                this.lastClickedChip = null;
+            }
+
             const contextId = this.cdpService.getPrimaryContextId();
             const callParams: Record<string, unknown> = {
-                expression: DETECT_PLANNING_SCRIPT,
+                expression: buildDetectPlanningScript(this.lastClickedChip?.text || null),
                 returnByValue: true,
                 awaitPromise: false,
             };
@@ -303,9 +349,23 @@ export class PlanningDetector {
             }
 
             const result = await this.cdpService.call('Runtime.evaluate', callParams);
-            const info: PlanningInfo | null = result?.result?.value ?? null;
+            
+            // Expected shape is either PlanningInfo, or { collapsed: true, chipText: string }, or null
+            const payload = result?.result?.value ?? null;
+            
+            if (payload && payload.collapsed) {
+                // We just initiated an auto-click on a collapsed chip
+                this.lastClickedChip = { text: payload.chipText, at: Date.now() };
+                logger.debug(`[PlanningDetector] Auto-clicked collapsed artifact chip: "${payload.chipText}"`);
+                return; // Wait for the next poll cycle to detect the expanded buttons
+            }
+
+            const info: PlanningInfo | null = payload;
 
             if (info) {
+                // Clear click-guard state (successful expansion)
+                this.lastClickedChip = null;
+                
                 // Duplicate prevention: use button text pair as key (stable across DOM redraws)
                 const key = `${info.openText}::${info.proceedText}`;
                 const now = Date.now();

--- a/src/services/planningDetector.ts
+++ b/src/services/planningDetector.ts
@@ -14,6 +14,12 @@ export interface PlanningInfo {
     planSummary: string;
     /** Plan description (markdown rendered in leading-relaxed container) */
     description: string;
+    /**
+     * True when the plan was detected as a plain file reference ("Files Modified" row)
+     * with no interactive buttons. The Telegram UI should present synthetic Open/Proceed
+     * buttons and must NOT call clickOpenButton() since there is nothing to click.
+     */
+    fileRefMode?: boolean;
 }
 
 export interface PlanningDetectorOptions {
@@ -25,28 +31,72 @@ export interface PlanningDetectorOptions {
     onPlanningRequired: (info: PlanningInfo) => void;
     /** Callback when a previously detected planning state is resolved (buttons disappeared) */
     onResolved?: () => void;
+    /** Callback when a read-only artifact (Walkthrough, Task) is auto-opened (no Proceed button) */
+    onAutoOpened?: (chipText: string) => void;
 }
+
+/**
+ * Selector that matches Antigravity artifact chips.
+ *
+ * Live DOM inspection confirmed the chip container uses:
+ *   div.border.border-gray-500/20.p-2.my-0.5.rounded-lg.transition-colors.flex.flex-col.gap-2.items-start.select-none
+ *
+ * Key classes:
+ *   1. "border-gray-500" — the border colour token (unique to plan chips)
+ *   2. "select-none"     — non-selectable text (unique to chip styling)
+ *
+ * NOTE: "cursor-pointer" is NOT on the chip container — it's only on inner
+ * elements. Prior selector was broken because of this false requirement.
+ */
+const ARTIFACT_CHIP_SELECTOR =
+    'div[class*="border-gray-500"][class*="select-none"]';
+
+/**
+ * Baseline capture script — returns counts of existing artifacts in the DOM.
+ * Called once when monitoring begins to establish what already exists.
+ * Also captures the count of implementation-plan-icon elements for the
+ * "Files Modified" detection path.
+ */
+const CAPTURE_BASELINE_SCRIPT = `(() => {
+    const chipSelector = '${ARTIFACT_CHIP_SELECTOR}';
+    return {
+        notifyCount: document.querySelectorAll('.notify-user-container').length,
+        cardCount: document.querySelectorAll(chipSelector).length,
+        iconCount: document.querySelectorAll('[class*="implementation-plan-icon"]').length
+    };
+})()`;
 
 /**
  * Detection script for the Antigravity UI planning mode.
  *
- * Looks for Open/Proceed button pairs inside .notify-user-container
- * and extracts plan metadata from the surrounding DOM elements.
+ * Uses baseline counts to skip artifacts that existed BEFORE the current session.
+ * Only considers .notify-user-container elements and artifact cards at indices
+ * >= the baseline counts, ensuring old session artifacts are never detected.
  */
-const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
+const buildDetectPlanningScript = (
+    lastClickedText: string | null,
+    baselineNotifyCount: number,
+    baselineCardCount: number,
+    baselineIconCount: number,
+) => `(() => {
     const OPEN_PATTERNS = ['open', 'view'];
-    const PROCEED_PATTERNS = ['proceed', 'accept', 'approve'];
+    const PROCEED_PATTERNS = ['proceed', 'accept', 'approve', 'continue'];
+    /**
+     * Artifact types that require user decision (Proceed + Open) or at least
+     * a Telegram notification (Open-only). These are NOT auto-opened silently.
+     */
+    const PLAN_TYPE_KEYWORDS = ['implementation plan', 'implementation_plan', 'plan', 'walkthrough', 'task'];
     const lastClickedText = ${lastClickedText ? JSON.stringify(lastClickedText) : 'null'};
+    const BASELINE_NOTIFY = ${baselineNotifyCount};
+    const BASELINE_CARD = ${baselineCardCount};
+    const BASELINE_ICON = ${baselineIconCount};
 
     const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
 
-    // Scope to the latest assistant message to avoid detecting old plans
-    const messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
-    const latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
-
-    // Find the notify container that holds planning UI - prefer the last one
-    const containers = Array.from(document.querySelectorAll('.notify-user-container'));
-    let container = containers.length > 0 ? containers[containers.length - 1] : null;
+    // Only consider .notify-user-container elements beyond the baseline
+    const allContainers = Array.from(document.querySelectorAll('.notify-user-container'));
+    const newContainers = allContainers.slice(BASELINE_NOTIFY);
+    let container = newContainers.length > 0 ? newContainers[newContainers.length - 1] : null;
     let openBtn = null;
     let proceedBtn = null;
 
@@ -54,56 +104,159 @@ const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
         const allButtons = Array.from(container.querySelectorAll('button')).filter(btn => btn.offsetParent !== null);
         openBtn = allButtons.find(btn => { const t = normalize(btn.textContent); return OPEN_PATTERNS.some(p => t === p || t.includes(p)); });
         proceedBtn = allButtons.find(btn => { const t = normalize(btn.textContent); return PROCEED_PATTERNS.some(p => t === p || t.includes(p)); });
-    } else {
-        const docBtns = Array.from(latestMsg.querySelectorAll('button')).filter(btn => btn.offsetParent !== null);
-        openBtn = docBtns.find(btn => { const t = normalize(btn.textContent); return OPEN_PATTERNS.some(p => t === p || t.includes(p)); });
-        proceedBtn = docBtns.find(btn => { const t = normalize(btn.textContent); return PROCEED_PATTERNS.some(p => t === p || t.includes(p)); });
-        
-        if (openBtn) {
-            let p = openBtn.parentElement;
-            if (proceedBtn) {
-                p = proceedBtn.parentElement;
-                while (p && p !== document.body && !p.contains(openBtn)) { p = p.parentElement; }
-            }
-            if (p) {
-                container = p.closest('[class*="border"][class*="rounded"]');
-                if (!container) container = p.parentElement ? p.parentElement.parentElement : null;
+    }
+
+    // If no container found in new containers, check for loose buttons in new containers only
+    if (!openBtn && newContainers.length > 0) {
+        for (let ci = newContainers.length - 1; ci >= 0; ci--) {
+            const c = newContainers[ci];
+            const btns = Array.from(c.querySelectorAll('button')).filter(btn => btn.offsetParent !== null);
+            const ob = btns.find(btn => { const t = normalize(btn.textContent); return OPEN_PATTERNS.some(p => t === p || t.includes(p)); });
+            if (ob) {
+                openBtn = ob;
+                container = c;
+                proceedBtn = btns.find(btn => { const t = normalize(btn.textContent); return PROCEED_PATTERNS.some(p => t === p || t.includes(p)); });
+                break;
             }
         }
     }
 
-    // Fallback: Check for collapsed artifact cards in the latest message
+    // Fallback: Check for collapsed/expanded artifact chips beyond baseline.
+    // Antigravity renders artifact chips as div.border-gray.cursor-pointer blocks.
+    // Collapsed chips have NO buttons — clicking expands them to reveal Proceed/Open.
+    // Expanded chips contain Proceed/Open buttons directly inside the div.
     if (!openBtn || !container) {
-        const cards = Array.from(latestMsg.querySelectorAll('div[class*="border"][class*="rounded-lg"]'));
-        for (const card of cards) {
-            const chip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
-            if (chip && card.offsetParent !== null) {
-                const text = (chip.textContent || '').trim();
-                const buttons = Array.from(card.querySelectorAll('button'));
-                const hasOpenOrProceed = buttons.some(btn => {
-                    const t = normalize(btn.textContent);
-                    return OPEN_PATTERNS.some(p => t === p || t.includes(p)) || t.includes('proceed');
-                });
-                if (!hasOpenOrProceed) {
-                    if (text && text !== lastClickedText) {
-                        chip.click();
-                        return { collapsed: true, chipText: text };
+        const chipSelector = '${ARTIFACT_CHIP_SELECTOR}';
+        const allCards = Array.from(document.body.querySelectorAll(chipSelector))
+            .filter(el => el.offsetParent !== null);
+        const newCards = allCards.slice(BASELINE_CARD);
+
+        // Iterate backwards to process the newest artifacts first
+        for (let i = newCards.length - 1; i >= 0; i--) {
+            const card = newCards[i];
+            const cardText = (card.textContent || '').trim();
+            if (!cardText || cardText.length > 500) continue;
+
+            // Check if card is EXPANDED (has Open/Proceed buttons inside)
+            const buttons = Array.from(card.querySelectorAll('button'))
+                .filter(btn => btn.offsetParent !== null);
+            const ob = buttons.find(btn => {
+                const t = normalize(btn.textContent);
+                return OPEN_PATTERNS.some(p => t === p || t.includes(p));
+            });
+            const pb = buttons.find(btn => {
+                const t = normalize(btn.textContent);
+                return PROCEED_PATTERNS.some(p => t === p || t.includes(p));
+            });
+
+            if (ob) {
+                if (!pb) {
+                    // Open-only chip: determine if it's a plan-type artifact.
+                    // Plan-types (implementation plan, walkthrough, task) must go through
+                    // Telegram notification so the user can decide — NOT auto-opened.
+                    const cardNorm = normalize(card.textContent);
+                    const isPlanType = PLAN_TYPE_KEYWORDS.some(k => cardNorm.includes(k))
+                        || !!card.querySelector('[class*="implementation-plan-icon"]')
+                        || !!card.querySelector('[class*="walkthrough-icon"]')
+                        || !!card.querySelector('[class*="task-icon"]');
+
+                    if (isPlanType) {
+                        // Needs a Telegram notification — hand off as a full plan detection with no proceedText
+                        openBtn = ob;
+                        proceedBtn = null;
+                        container = card;
+                        break;
+                    }
+
+                    // Non-plan open-only artifact — auto-open silently as before
+                    const nameSpans = Array.from(card.querySelectorAll('span'))
+                        .map(s => (s.textContent || '').trim())
+                        .filter(t => t.length > 0 && t.length < 60
+                            && !OPEN_PATTERNS.some(p => normalize(t) === p || normalize(t).includes(p)));
+                    ob.click();
+                    return { autoOpened: true, chipText: nameSpans[0] || 'Artifact' };
+                }
+                // Has both Open AND Proceed — needs user decision
+                openBtn = ob;
+                proceedBtn = pb;
+                container = card;
+                break;
+            }
+
+            // COLLAPSED chip (no visible buttons yet) — check if it's a plan type by icon.
+            // Plan-type chips must be expanded via click so their buttons can be detected
+            // on the next poll cycle. Non-plan chips are ignored to avoid false positives.
+            const hasPlanIcon = !!card.querySelector('[class*="implementation-plan-icon"]')
+                || !!card.querySelector('[class*="walkthrough-icon"]')
+                || !!card.querySelector('[class*="task-icon"]');
+            const cardTextNorm = normalize(card.textContent);
+            const looksLikePlan = hasPlanIcon || PLAN_TYPE_KEYWORDS.some(k => cardTextNorm.includes(k));
+
+            if (looksLikePlan) {
+                // Try inner clickable span first, then the div itself.
+                const innerChip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
+                const clickTarget = innerChip || (card.classList.contains('cursor-pointer') ? card : null);
+                if (clickTarget) {
+                    const chipText = (clickTarget.textContent || '').trim();
+                    if (chipText && chipText !== lastClickedText && chipText.length < 100) {
+                        clickTarget.click();
+                        return { collapsed: true, chipText };
                     }
                 }
             }
         }
-        return null; // Both failed
+
+        if (!openBtn) {
+            // ── 4th detection pass: "Files Modified" file-reference chips ────────────
+            // These chips have the implementation-plan-icon but NO buttons (not rendered
+            // as a notify-user-container or border-gray chip). They appear as plain file
+            // references under the "Files Modified" header of an AI response.
+            const allIconEls = Array.from(document.querySelectorAll('[class*="implementation-plan-icon"]'))
+                .filter(el => el.offsetParent !== null);
+            const newIconEls = allIconEls.slice(BASELINE_ICON);
+
+            for (let k = newIconEls.length - 1; k >= 0; k--) {
+                const iconEl = newIconEls[k];
+                // Walk up to find the clickable file-reference row
+                let refEl = iconEl.parentElement;
+                for (let up = 0; up < 5 && refEl; up++) {
+                    if (refEl.classList.contains('cursor-pointer') || refEl.getAttribute('role') === 'button') break;
+                    refEl = refEl.parentElement;
+                }
+
+                // Extract plan title from the icon's sibling text.
+                // The monaco-icon-label includes both the type prefix (e.g. "Implementation Plan")
+                // and the actual filename — strip the known prefix to get just the file name.
+                const titleNode = iconEl.closest('[class*="monaco-icon-label"]') ||
+                    iconEl.parentElement;
+                const rawTitle = (titleNode?.textContent || '').trim();
+                // Remove leading type-prefix tokens so "Implementation PlanFoo Bar" → "Foo Bar"
+                const PLAN_PREFIX_RE = /^(implementation plan|implementation_plan|walkthrough|task)\s*/i;
+                const planTitle = rawTitle.replace(PLAN_PREFIX_RE, '').trim() || rawTitle || 'Implementation Plan';
+
+                // Synthesize openText since there's no actual Open button
+                return {
+                    openText: 'Open',
+                    proceedText: null,
+                    planTitle,
+                    planSummary: '',
+                    description: '',
+                    fileRefMode: true, // Signal to TypeScript layer that there's no button to click
+                };
+            }
+
+            return null; // No new artifacts found
+        }
     }
 
     const openText = (openBtn.textContent || '').trim();
     const proceedText = proceedBtn ? (proceedBtn.textContent || '').trim() : null;
 
     // Extract plan title from .inline-flex.break-all or .font-mono
-    const titleEl = container.querySelector('span.inline-flex.break-all, .inline-flex.break-all, .font-mono.text-sm.truncate, .font-mono.truncate');
+    const titleEl = container.querySelector('span.inline-flex.break-all, .inline-flex.break-all, span.break-all, span.select-text.break-all, .font-mono.text-sm.truncate, .font-mono.truncate');
     let planTitle = titleEl ? (titleEl.textContent || '').trim() : '';
 
     if (!planTitle && openText) {
-        // Fallback: extract from open button text (e.g., "Open task.md" -> "task.md")
         const match = openText.match(/open\\s+(.*)/i);
         if (match) planTitle = match[1].trim();
     }
@@ -115,11 +268,13 @@ const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
         .filter(text => text.length > 0 && text !== openText && text !== proceedText && text !== planTitle)
         .join(' ');
 
-    // Extract description from leading-relaxed container, skipping code/style blocks
+    // Extract description from leading-relaxed container, skipping code/style blocks.
+    // Fallback: if no .leading-relaxed found (chip-based layout), collect all non-button
+    // text from the container minus title/summary text.
     const descEl = container.querySelector('.leading-relaxed.select-text');
     let description = '';
-    if (descEl) {
-        const SKIP_TAGS = new Set(['PRE', 'CODE', 'STYLE', 'SCRIPT']);
+    const SKIP_TAGS = new Set(['PRE', 'CODE', 'STYLE', 'SCRIPT', 'BUTTON']);
+    const walkToText = (el) => {
         const parts = [];
         const walk = (node) => {
             if (node.nodeType === 3) {
@@ -129,8 +284,17 @@ const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
                 for (const child of node.childNodes) walk(child);
             }
         };
-        walk(descEl);
-        description = parts.join(' ').slice(0, 500);
+        walk(el);
+        return parts.join(' ').slice(0, 500);
+    };
+    if (descEl) {
+        description = walkToText(descEl);
+    } else {
+        // Chip-based layout: extract all container text excluding buttons and title
+        const fullText = walkToText(container);
+        // Remove the title and button text from the full container text
+        const strippedParts = [planTitle, openText, proceedText, planSummary].filter(Boolean);
+        description = strippedParts.reduce((t, s) => t.replace(s, ''), fullText).replace(/\\s+/g, ' ').trim();
     }
 
     return { openText, proceedText, planTitle, planSummary, description };
@@ -142,7 +306,17 @@ const buildDetectPlanningScript = (lastClickedText: string | null) => `(() => {
  * Looks for the rendered markdown inside the plan content area
  * and returns the text, truncated to 4000 characters for Telegram message limits.
  */
-const EXTRACT_PLAN_CONTENT_SCRIPT = `(() => {
+/**
+ * Build plan content extraction script with baseline counts.
+ * Only extracts content from artifacts beyond the baseline.
+ */
+const buildExtractPlanContentScript = (
+    baselineNotifyCount: number,
+    baselineCardCount: number,
+) => `(() => {
+    const BASELINE_NOTIFY = ${baselineNotifyCount};
+    const BASELINE_CARD = ${baselineCardCount};
+
     // Simple HTML-to-Markdown converter for plan content
     const htmlToMd = (el) => {
         const parts = [];
@@ -182,33 +356,46 @@ const EXTRACT_PLAN_CONTENT_SCRIPT = `(() => {
         return parts.join('').replace(/\\n{3,}/g, '\\n\\n').trim();
     };
 
-    // Primary selector: plan content container
-    const contentContainer = document.querySelector(
-        'div.relative.pl-4.pr-4.py-1, div.relative.pl-4.pr-4'
-    );
-    if (contentContainer) {
-        const textEl = contentContainer.querySelector('.leading-relaxed.select-text');
+    // Only look at NEW notify containers (beyond baseline)
+    const allContainers = Array.from(document.querySelectorAll('.notify-user-container'));
+    const newContainers = allContainers.slice(BASELINE_NOTIFY);
+
+    // Try extracting from the newest new container first
+    for (let i = newContainers.length - 1; i >= 0; i--) {
+        const container = newContainers[i];
+        // Look for content inside the container
+        const contentDiv = container.querySelector('div.relative.pl-4.pr-4.py-1, div.relative.pl-4.pr-4');
+        if (contentDiv) {
+            const textEl = contentDiv.querySelector('.leading-relaxed.select-text');
+            if (textEl) return htmlToMd(textEl);
+        }
+        // Direct leading-relaxed inside container
+        const directLeading = container.querySelector('.leading-relaxed.select-text');
+        if (directLeading) {
+            const md = htmlToMd(directLeading);
+            if (md.length > 50) return md;
+        }
+    }
+
+    // Fallback: look for new artifact cards/chips beyond baseline
+    const chipSelector = '${ARTIFACT_CHIP_SELECTOR}';
+    const allCards = Array.from(document.body.querySelectorAll(chipSelector));
+    const newCards = allCards.slice(BASELINE_CARD);
+    for (let i = newCards.length - 1; i >= 0; i--) {
+        const card = newCards[i];
+        const textEl = card.querySelector('.leading-relaxed.select-text');
         if (textEl) {
-            return htmlToMd(textEl);
+            const md = htmlToMd(textEl);
+            if (md.length > 50) return md;
         }
     }
 
-    // Fallback 1: Common markdown container classes
-    const mdContainers = Array.from(document.querySelectorAll(
-        '[data-testid="markdown-content"], .markdown-body, .prose'
-    ));
-    for (const container of mdContainers) {
-        const md = htmlToMd(container);
-        if (md.length > 50) return md;
-    }
-
-    // Fallback 2: any leading-relaxed.select-text with significant content
-    const allLeading = Array.from(document.querySelectorAll('.leading-relaxed.select-text'));
-    for (const el of allLeading) {
-        const md = htmlToMd(el);
-        if (md.length > 100) {
-            return md;
-        }
+    // Last resort: any content container beyond baseline position-wise
+    const allContentDivs = Array.from(document.querySelectorAll('div.relative.pl-4.pr-4.py-1, div.relative.pl-4.pr-4'));
+    const newContentDivs = allContentDivs.slice(Math.max(BASELINE_NOTIFY, 0));
+    for (let i = newContentDivs.length - 1; i >= 0; i--) {
+        const textEl = newContentDivs[i].querySelector('.leading-relaxed.select-text');
+        if (textEl) return htmlToMd(textEl);
     }
 
     return null;
@@ -227,6 +414,7 @@ export class PlanningDetector {
     private pollIntervalMs: number;
     private onPlanningRequired: (info: PlanningInfo) => void;
     private onResolved?: () => void;
+    private onAutoOpened?: (chipText: string) => void;
 
     private pollTimer: NodeJS.Timeout | null = null;
     private isRunning: boolean = false;
@@ -242,14 +430,29 @@ export class PlanningDetector {
     /** Click-guard state to prevent infinite auto-click loops on collapsed cards */
     private lastClickedChip: { text: string; at: number } | null = null;
 
+    /**
+     * Baseline artifact counts captured when monitoring starts.
+     * Artifacts at indices < baseline are from previous sessions and are ignored.
+     */
+    private baselineNotifyCount: number = 0;
+    private baselineCardCount: number = 0;
+    private baselineIconCount: number = 0;
+
     constructor(options: PlanningDetectorOptions) {
         this.cdpService = options.cdpService;
         this.pollIntervalMs = options.pollIntervalMs ?? 2000;
         this.onPlanningRequired = options.onPlanningRequired;
         this.onResolved = options.onResolved;
+        this.onAutoOpened = options.onAutoOpened;
     }
 
-    /** Start monitoring. */
+    /**
+     * Start monitoring.
+     *
+     * Captures a DOM baseline BEFORE the first poll so that any plan artifacts
+     * already in the DOM (e.g. from a prior session) are never treated as new
+     * detections and do not produce false-positive Telegram notifications.
+     */
     start(): void {
         if (this.isRunning) return;
         this.isRunning = true;
@@ -257,7 +460,46 @@ export class PlanningDetector {
         this.lastDetectedInfo = null;
         this.lastNotifiedAt = 0;
         this.lastClickedChip = null;
-        this.schedulePoll();
+        // Capture baseline before the first poll — runs async but schedules
+        // the first poll only after the baseline is safely captured.
+        this.resetBaseline().finally(() => {
+            if (this.isRunning) this.schedulePoll();
+        });
+    }
+
+    /**
+     * Capture a baseline snapshot of existing artifacts in the DOM.
+     * Must be called BEFORE a new message is submitted so that
+     * detection only triggers on NEW artifacts from the current session.
+     */
+    async resetBaseline(): Promise<void> {
+        try {
+            const result = await this.runEvaluateScript(CAPTURE_BASELINE_SCRIPT);
+            this.baselineNotifyCount = result?.notifyCount ?? 0;
+            this.baselineCardCount = result?.cardCount ?? 0;
+            this.baselineIconCount = result?.iconCount ?? 0;
+            // Reset detection state so new plans can be detected
+            this.lastDetectedKey = null;
+            this.lastDetectedInfo = null;
+            this.lastNotifiedAt = 0;
+            this.lastClickedChip = null;
+            logger.debug(
+                `[PlanningDetector] Baseline captured: ${this.baselineNotifyCount} notify containers, ` +
+                `${this.baselineCardCount} chips, ${this.baselineIconCount} plan icons`,
+            );
+        } catch (error) {
+            logger.error('[PlanningDetector] Failed to capture baseline:', error);
+            // On failure, keep existing baselines (safe: won't detect old artifacts)
+        }
+    }
+
+    /** Get the current baseline counts (for passing to other scripts) */
+    getBaseline(): { notifyCount: number; cardCount: number; iconCount: number } {
+        return {
+            notifyCount: this.baselineNotifyCount,
+            cardCount: this.baselineCardCount,
+            iconCount: this.baselineIconCount,
+        };
     }
 
     /** Stop monitoring. */
@@ -306,7 +548,8 @@ export class PlanningDetector {
      */
     async extractPlanContent(): Promise<string | null> {
         try {
-            const result = await this.runEvaluateScript(EXTRACT_PLAN_CONTENT_SCRIPT);
+            const script = buildExtractPlanContentScript(this.baselineNotifyCount, this.baselineCardCount);
+            const result = await this.runEvaluateScript(script);
             return typeof result === 'string' ? result : null;
         } catch (error) {
             logger.error('[PlanningDetector] Error extracting plan content:', error);
@@ -340,7 +583,12 @@ export class PlanningDetector {
 
             const contextId = this.cdpService.getPrimaryContextId();
             const callParams: Record<string, unknown> = {
-                expression: buildDetectPlanningScript(this.lastClickedChip?.text || null),
+                expression: buildDetectPlanningScript(
+                    this.lastClickedChip?.text || null,
+                    this.baselineNotifyCount,
+                    this.baselineCardCount,
+                    this.baselineIconCount,
+                ),
                 returnByValue: true,
                 awaitPromise: false,
             };
@@ -350,7 +598,7 @@ export class PlanningDetector {
 
             const result = await this.cdpService.call('Runtime.evaluate', callParams);
             
-            // Expected shape is either PlanningInfo, or { collapsed: true, chipText: string }, or null
+            // Expected shape: PlanningInfo | PlanningInfo+fileRefMode | { collapsed: true, chipText } | { autoOpened: true, chipText } | null
             const payload = result?.result?.value ?? null;
             
             if (payload && payload.collapsed) {
@@ -360,17 +608,38 @@ export class PlanningDetector {
                 return; // Wait for the next poll cycle to detect the expanded buttons
             }
 
+            if (payload && payload.autoOpened) {
+                // Read-only artifact (Walkthrough, Task) was auto-opened — send lightweight notification
+                this.lastClickedChip = null;
+                logger.info(`[PlanningDetector] Auto-opened read-only artifact: "${payload.chipText}"`);
+                if (this.onAutoOpened) {
+                    Promise.resolve(this.onAutoOpened(payload.chipText)).catch((err) => {
+                        logger.error('[PlanningDetector] onAutoOpened callback failed:', err);
+                    });
+                }
+                return;
+            }
+
             const info: PlanningInfo | null = payload;
 
             if (info) {
                 // Clear click-guard state (successful expansion)
                 this.lastClickedChip = null;
                 
-                // Duplicate prevention: use button text pair as key (stable across DOM redraws)
-                const key = `${info.openText}::${info.proceedText}`;
+                // Duplicate prevention: use button text + content preview as key (stable across DOM redraws, unique per plan)
+                const uniquePreview = `${info.planTitle}::${info.planSummary.slice(0, 50)}::${info.description.slice(0, 50)}`;
+                const key = `${info.openText}::${info.proceedText}::${uniquePreview}`;
                 const now = Date.now();
                 const withinCooldown = (now - this.lastNotifiedAt) < PlanningDetector.COOLDOWN_MS;
-                if (key !== this.lastDetectedKey && !withinCooldown) {
+
+                // Allow "upgrade" notifications: if the previous detection was fileRefMode or had no
+                // proceedText, and the new detection has a real Proceed button, always re-notify —
+                // this is a better version of the same plan and the user must be able to Proceed.
+                const isUpgrade = !!(info.proceedText &&
+                    this.lastDetectedInfo &&
+                    (this.lastDetectedInfo.fileRefMode || !this.lastDetectedInfo.proceedText));
+
+                if (key !== this.lastDetectedKey && (!withinCooldown || isUpgrade)) {
                     this.lastDetectedKey = key;
                     this.lastDetectedInfo = info;
                     this.lastNotifiedAt = now;
@@ -381,6 +650,7 @@ export class PlanningDetector {
                     // Same key — update stored info silently
                     this.lastDetectedInfo = info;
                 }
+
             } else {
                 // Reset when buttons disappear (prepare for next planning detection)
                 const wasDetected = this.lastDetectedKey !== null;

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -139,9 +139,12 @@ export const RESPONSE_SELECTORS = {
     })()`,
     /** Check if planning dialog (Open/Proceed buttons) is active */
     PLANNING_ACTIVE: `(() => {
-        var container = document.querySelector('.notify-user-container');
-        if (!container) return false;
-        var buttons = Array.from(container.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
+        var messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
+        var latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
+        var containers = Array.from(document.querySelectorAll('.notify-user-container'));
+        var container = containers.length > 0 ? containers[containers.length - 1] : null;
+        var buttons = container ? Array.from(container.querySelectorAll('button')) : Array.from(latestMsg.querySelectorAll('button'));
+        buttons = buttons.filter(function(btn) { return btn.offsetParent !== null; });
         var hasOpen = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'open'; });
         var hasProceed = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'proceed'; });
         return hasOpen && hasProceed;
@@ -406,15 +409,38 @@ export const RESPONSE_SELECTORS = {
 
         // --- Planning active ---
         let planningActive = false;
-        const container = document.querySelector('.notify-user-container');
+        const OPEN_PAT = ['open', 'view'];
+        const btnNorm = function(btn) { return (btn.textContent || '').toLowerCase().replace(/\\s+/g, ' ').trim(); };
+        const messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
+        const latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
+        const containers = Array.from(document.querySelectorAll('.notify-user-container'));
+        const container = containers.length > 0 ? containers[containers.length - 1] : null;
+
         if (container) {
             const buttons = Array.from(container.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
-            const OPEN_PAT = ['open', 'view'];
-            const PROCEED_PAT = ['proceed', 'accept', 'approve'];
-            const btnNorm = function(btn) { return (btn.textContent || '').toLowerCase().replace(/\\s+/g, ' ').trim(); };
-            const hasOpen = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
-            const hasProceed = buttons.some(function(btn) { var t = btnNorm(btn); return PROCEED_PAT.some(function(p) { return t === p || t.includes(p); }); });
-            planningActive = hasOpen;
+            planningActive = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
+        } else {
+            const buttons = Array.from(latestMsg.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
+            planningActive = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
+            
+            if (!planningActive) {
+                const cards = Array.from(latestMsg.querySelectorAll('div[class*="border"][class*="rounded-lg"]'));
+                for (let i = 0; i < cards.length; i++) {
+                    const card = cards[i];
+                    const chip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
+                    if (chip && card.offsetParent !== null) {
+                        const buttons = Array.from(card.querySelectorAll('button'));
+                        const hasOpenOrProceed = buttons.some(function(btn) {
+                            const t = btnNorm(btn);
+                            return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }) || t.includes('proceed');
+                        });
+                        if (!hasOpenOrProceed) {
+                            planningActive = true;
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         // --- Legacy text extraction ---

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -376,14 +376,15 @@ export const RESPONSE_SELECTORS = {
         // --- Quota error ---
         let quotaError = false;
         const scope = panel || document;
-        const QUOTA_KEYWORDS = ['model quota reached', 'rate limit', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
+        const QUOTA_KEYWORDS_PRIMARY = ['model quota reached', 'rate limit', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
+        const QUOTA_KEYWORDS_FALLBACK = ['model quota reached', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
         const isInsideResponse = (node) =>
             node.closest('.rendered-markdown, .prose, pre, code, [data-message-author-role="assistant"], [data-message-role="assistant"], [class*="message-content"]');
         const headings = scope.querySelectorAll('h3 span, h3');
         for (const el of headings) {
             if (isInsideResponse(el)) continue;
             const text = (el.textContent || '').trim().toLowerCase();
-            if (QUOTA_KEYWORDS.some(kw => text.includes(kw))) { quotaError = true; break; }
+            if (QUOTA_KEYWORDS_PRIMARY.some(kw => text.includes(kw))) { quotaError = true; break; }
         }
         if (!quotaError) {
             const inlineSpans = scope.querySelectorAll('span');
@@ -399,7 +400,7 @@ export const RESPONSE_SELECTORS = {
             for (const el of errorElements) {
                 if (isInsideResponse(el)) continue;
                 const text = (el.textContent || '').trim().toLowerCase();
-                if (QUOTA_KEYWORDS.some(kw => text.includes(kw))) { quotaError = true; break; }
+                if (QUOTA_KEYWORDS_FALLBACK.some(kw => text.includes(kw))) { quotaError = true; break; }
             }
         }
 
@@ -408,9 +409,12 @@ export const RESPONSE_SELECTORS = {
         const container = document.querySelector('.notify-user-container');
         if (container) {
             const buttons = Array.from(container.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
-            const hasOpen = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'open'; });
-            const hasProceed = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'proceed'; });
-            planningActive = hasOpen && hasProceed;
+            const OPEN_PAT = ['open', 'view'];
+            const PROCEED_PAT = ['proceed', 'accept', 'approve'];
+            const btnNorm = function(btn) { return (btn.textContent || '').toLowerCase().replace(/\\s+/g, ' ').trim(); };
+            const hasOpen = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
+            const hasProceed = buttons.some(function(btn) { var t = btnNorm(btn); return PROCEED_PAT.some(function(p) { return t === p || t.includes(p); }); });
+            planningActive = hasOpen;
         }
 
         // --- Legacy text extraction ---
@@ -511,7 +515,8 @@ export const RESPONSE_SELECTORS = {
     QUOTA_ERROR: `(() => {
         const panel = document.querySelector('.antigravity-agent-side-panel');
         const scope = panel || document;
-        const QUOTA_KEYWORDS = ['model quota reached', 'rate limit', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
+        const QUOTA_KEYWORDS_PRIMARY = ['model quota reached', 'rate limit', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
+        const QUOTA_KEYWORDS_FALLBACK = ['model quota reached', 'quota exceeded', 'exhausted your quota', 'exhausted quota'];
         const isInsideResponse = (node) =>
             node.closest('.rendered-markdown, .prose, pre, code, [data-message-author-role="assistant"], [data-message-role="assistant"], [class*="message-content"]');
 
@@ -520,7 +525,7 @@ export const RESPONSE_SELECTORS = {
         for (const el of headings) {
             if (isInsideResponse(el)) continue;
             const text = (el.textContent || '').trim().toLowerCase();
-            if (QUOTA_KEYWORDS.some(kw => text.includes(kw))) return true;
+            if (QUOTA_KEYWORDS_PRIMARY.some(kw => text.includes(kw))) return true;
         }
 
         // Inline error: "Error You have exhausted your quota on this model."
@@ -548,7 +553,7 @@ export const RESPONSE_SELECTORS = {
         for (const el of errorElements) {
             if (isInsideResponse(el)) continue;
             const text = (el.textContent || '').trim().toLowerCase();
-            if (QUOTA_KEYWORDS.some(kw => text.includes(kw))) return true;
+            if (QUOTA_KEYWORDS_FALLBACK.some(kw => text.includes(kw))) return true;
         }
         return false;
     })()`,

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -137,18 +137,8 @@ export const RESPONSE_SELECTORS = {
 
         return { isGenerating: false };
     })()`,
-    /** Check if planning dialog (Open/Proceed buttons) is active */
-    PLANNING_ACTIVE: `(() => {
-        var messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
-        var latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
-        var containers = Array.from(document.querySelectorAll('.notify-user-container'));
-        var container = containers.length > 0 ? containers[containers.length - 1] : null;
-        var buttons = container ? Array.from(container.querySelectorAll('button')) : Array.from(latestMsg.querySelectorAll('button'));
-        buttons = buttons.filter(function(btn) { return btn.offsetParent !== null; });
-        var hasOpen = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'open'; });
-        var hasProceed = buttons.some(function(btn) { return (btn.textContent || '').toLowerCase().trim() === 'proceed'; });
-        return hasOpen && hasProceed;
-    })()`,
+    /** Check if planning dialog (Open/Proceed buttons) is active — now baseline-aware */
+    PLANNING_ACTIVE: '(() => false)()', // Deprecated: use COMBINED_POLL with baseline counts
     /** Click stop button via tooltip-id + text fallback */
     CLICK_STOP_BUTTON: `(() => {
         const panel = document.querySelector('.antigravity-agent-side-panel');
@@ -350,8 +340,11 @@ export const RESPONSE_SELECTORS = {
 
         return results;
     })()`,
-    /** Combined poll script — stop button + quota error + legacy text in one CDP call */
-    COMBINED_POLL: `(() => {
+    /** Combined poll script — stop button + quota error + legacy text in one CDP call.
+     *  NOTE: The planning section uses BASELINE_NOTIFY and BASELINE_CARD placeholders
+     *  that must be replaced with actual baseline counts before evaluation.
+     *  Use buildCombinedPollScript() to inject the correct values. */
+    COMBINED_POLL_TEMPLATE: `(() => {
         const panel = document.querySelector('.antigravity-agent-side-panel');
         const scopes = [panel, document].filter(Boolean);
 
@@ -407,37 +400,40 @@ export const RESPONSE_SELECTORS = {
             }
         }
 
-        // --- Planning active ---
+        // --- Planning active (baseline-aware) ---
         let planningActive = false;
+        const BASELINE_NOTIFY = __BASELINE_NOTIFY__;
+        const BASELINE_CARD = __BASELINE_CARD__;
         const OPEN_PAT = ['open', 'view'];
         const btnNorm = function(btn) { return (btn.textContent || '').toLowerCase().replace(/\\s+/g, ' ').trim(); };
-        const messages = Array.from(document.querySelectorAll('[data-message-author-role="assistant"], [data-message-role="assistant"], [class*="assistant-message"]'));
-        const latestMsg = messages.length > 0 ? messages[messages.length - 1] : document;
-        const containers = Array.from(document.querySelectorAll('.notify-user-container'));
-        const container = containers.length > 0 ? containers[containers.length - 1] : null;
+
+        // Only consider .notify-user-container elements beyond the baseline
+        const allContainers = Array.from(document.querySelectorAll('.notify-user-container'));
+        const newContainers = allContainers.slice(BASELINE_NOTIFY);
+        const container = newContainers.length > 0 ? newContainers[newContainers.length - 1] : null;
 
         if (container) {
             const buttons = Array.from(container.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
             planningActive = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
-        } else {
-            const buttons = Array.from(latestMsg.querySelectorAll('button')).filter(function(btn) { return btn.offsetParent !== null; });
-            planningActive = buttons.some(function(btn) { var t = btnNorm(btn); return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }); });
-            
-            if (!planningActive) {
-                const cards = Array.from(latestMsg.querySelectorAll('div[class*="border"][class*="rounded-lg"]'));
-                for (let i = 0; i < cards.length; i++) {
-                    const card = cards[i];
-                    const chip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
-                    if (chip && card.offsetParent !== null) {
-                        const buttons = Array.from(card.querySelectorAll('button'));
-                        const hasOpenOrProceed = buttons.some(function(btn) {
-                            const t = btnNorm(btn);
-                            return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }) || t.includes('proceed');
-                        });
-                        if (!hasOpenOrProceed) {
-                            planningActive = true;
-                            break;
-                        }
+        }
+
+        if (!planningActive) {
+            // Check for collapsed artifact cards beyond baseline
+            const allCards = Array.from(document.body.querySelectorAll('div[class*="border"][class*="rounded-lg"]'));
+            const newCards = allCards.slice(BASELINE_CARD);
+
+            for (let i = newCards.length - 1; i >= 0; i--) {
+                const card = newCards[i];
+                const chip = card.querySelector('span[class*="inline-flex"][class*="cursor-pointer"]');
+                if (chip && card.offsetParent !== null) {
+                    const buttons = Array.from(card.querySelectorAll('button'));
+                    const hasOpenOrProceed = buttons.some(function(btn) {
+                        const t = btnNorm(btn);
+                        return OPEN_PAT.some(function(p) { return t === p || t.includes(p); }) || t.includes('proceed');
+                    });
+                    if (!hasOpenOrProceed) {
+                        planningActive = true;
+                        break;
                     }
                 }
             }
@@ -705,6 +701,13 @@ export class ResponseMonitor {
     /** Consecutive WebSocket error count — stops monitor after threshold */
     private consecutiveWsErrors: number = 0;
 
+    /**
+     * Baseline artifact counts captured at monitoring start.
+     * Used to exclude old-session artifacts from planning-active detection.
+     */
+    private baselineNotifyCount: number = 0;
+    private baselineCardCount: number = 0;
+
     constructor(options: ResponseMonitorOptions) {
         this.cdpService = options.cdpService;
         this.pollIntervalMs = options.pollIntervalMs ?? 2000;
@@ -718,6 +721,17 @@ export class ResponseMonitor {
         this.onPhaseChange = options.onPhaseChange;
         this.onProcessLog = options.onProcessLog;
         this.onThinkingLog = options.onThinkingLog;
+    }
+
+    /**
+     * Build the COMBINED_POLL script with current baseline counts injected.
+     * Replaces __BASELINE_NOTIFY__ and __BASELINE_CARD__ placeholders with
+     * the actual artifact counts captured at monitoring start.
+     */
+    private buildCombinedPollScript(): string {
+        return RESPONSE_SELECTORS.COMBINED_POLL_TEMPLATE
+            .replace('__BASELINE_NOTIFY__', String(this.baselineNotifyCount))
+            .replace('__BASELINE_CARD__', String(this.baselineCardCount));
     }
 
     /** Start monitoring */
@@ -750,6 +764,22 @@ export class ResponseMonitor {
         this.consecutiveWsErrors = 0;
 
         this.onPhaseChange?.(this.currentPhase, null);
+
+        // Capture artifact baseline FIRST — count existing notify containers and cards
+        // so the planning-active check in COMBINED_POLL can skip old-session artifacts
+        try {
+            const baselineResult = await this.cdpService.call('Runtime.evaluate', this.buildEvaluateParams(
+                `(() => ({ notifyCount: document.querySelectorAll('.notify-user-container').length, cardCount: document.querySelectorAll('div[class*="border"][class*="rounded-lg"]').length }))()`
+            ));
+            const bl = baselineResult?.result?.value;
+            if (bl) {
+                this.baselineNotifyCount = bl.notifyCount ?? 0;
+                this.baselineCardCount = bl.cardCount ?? 0;
+            }
+            logger.debug(`[ResponseMonitor] Artifact baseline: ${this.baselineNotifyCount} notify, ${this.baselineCardCount} cards`);
+        } catch {
+            // Best-effort; baseline stays at 0 (conservative: may still detect old artifacts)
+        }
 
         // Capture baselines in parallel (text + process logs + optional structured)
         const baselinePromises: Promise<any>[] = [
@@ -983,7 +1013,7 @@ export class ResponseMonitor {
             if (this.extractionMode === 'structured') {
                 // Structured mode: run combined (stop+quota+planning) in parallel with structured extraction
                 const [combinedResult, structuredResult] = await Promise.all([
-                    this.cdpService.call('Runtime.evaluate', this.buildEvaluateParams(RESPONSE_SELECTORS.COMBINED_POLL)),
+                    this.cdpService.call('Runtime.evaluate', this.buildEvaluateParams(this.buildCombinedPollScript())),
                     this.cdpService.call('Runtime.evaluate', this.buildEvaluateParams(RESPONSE_SELECTORS.RESPONSE_STRUCTURED)).catch(() => null),
                 ]);
 
@@ -1044,7 +1074,7 @@ export class ResponseMonitor {
                 // Legacy mode: single combined CDP call gets everything
                 const combinedResult = await this.cdpService.call(
                     'Runtime.evaluate',
-                    this.buildEvaluateParams(RESPONSE_SELECTORS.COMBINED_POLL),
+                    this.buildEvaluateParams(this.buildCombinedPollScript()),
                 );
                 const combined = combinedResult?.result?.value ?? {};
                 isGenerating = !!combined.isGenerating;

--- a/src/ui/planUi.ts
+++ b/src/ui/planUi.ts
@@ -87,18 +87,31 @@ export function buildPlanNotificationUI(
     targetChannelStr: string,
 ): PlanNotificationUI {
     const description = info.description || info.planSummary || 'A plan has been generated and is awaiting your review.';
+    const planName = info.planTitle || 'Implementation Plan';
+    
+    let typeLabel = 'Plan';
+    if (planName.toLowerCase().includes('task')) typeLabel = 'Task';
+    else if (planName.toLowerCase().includes('walkthrough')) typeLabel = 'Walkthrough';
 
-    let text = `\u{1F4CB} <b>Planning Mode</b>\n\n`;
+    let text = `\u{1F4CB} <b>${typeLabel} Ready</b>\n\n`;
     text += escapeHtml(description) + `\n\n`;
-    text += `<b>Plan:</b> ${escapeHtml(info.planTitle || 'Implementation Plan')}\n`;
+    text += `<b>${typeLabel}:</b> ${escapeHtml(planName)}\n`;
     text += `<b>Workspace:</b> ${escapeHtml(projectName)}`;
 
     const suffix = `${projectName}:${targetChannelStr}`;
-    const keyboard = new InlineKeyboard()
-        .text('\u{1F4D6} View Full Plan', `${PLAN_VIEW_BTN}:${suffix}`)
-        .text('\u25B6 Proceed', `${PLAN_PROCEED_BTN}:${suffix}`)
-        .row()
-        .text('\u270F\uFE0F Edit Plan', `${PLAN_EDIT_BTN}:${suffix}`)
+    const keyboard = new InlineKeyboard();
+
+    const openLabel = info.openText || `Open ${typeLabel}`;
+    keyboard.text(`\u{1F4D6} ${openLabel}`, `${PLAN_VIEW_BTN}:${suffix}`);
+
+    if (info.proceedText) {
+        const proceedLabel = info.proceedText;
+        const proceedIcon = proceedLabel.toLowerCase().includes('accept') || proceedLabel.toLowerCase().includes('approve') ? '✅' : '▶';
+        keyboard.text(`${proceedIcon} ${proceedLabel}`, `${PLAN_PROCEED_BTN}:${suffix}`);
+    }
+
+    keyboard.row()
+        .text(`\u270F\uFE0F Edit ${typeLabel}`, `${PLAN_EDIT_BTN}:${suffix}`)
         .text('\u{1F504} Refresh', `${PLAN_REFRESH_BTN}:${suffix}`);
 
     return { text, keyboard };
@@ -142,11 +155,19 @@ export function buildPlanContentUI(
     currentPage: number,
     projectName: string,
     targetChannelStr: string,
+    planTitle?: string,
+    proceedText?: string,
 ): PlanContentPage {
     const page = pages[currentPage] || '(Page not found)';
     const totalPages = pages.length;
 
-    let text = `<b>\u{1F4CB} Plan Content</b>`;
+    let typeLabel = 'Plan';
+    if (planTitle) {
+        if (planTitle.toLowerCase().includes('task')) typeLabel = 'Task';
+        else if (planTitle.toLowerCase().includes('walkthrough')) typeLabel = 'Walkthrough';
+    }
+
+    let text = `<b>\u{1F4CB} ${typeLabel} Content</b>`;
     if (totalPages > 1) {
         text += ` (${currentPage + 1}/${totalPages})`;
     }
@@ -165,9 +186,12 @@ export function buildPlanContentUI(
         keyboard.row();
     }
 
-    // Action buttons on every plan content page
+    if (proceedText) {
+        const proceedIcon = proceedText.toLowerCase().includes('accept') || proceedText.toLowerCase().includes('approve') ? '✅' : '▶';
+        keyboard.text(`${proceedIcon} ${proceedText}`, `${PLAN_PROCEED_BTN}:${suffix}`);
+    }
+
     keyboard
-        .text('\u25B6 Proceed', `${PLAN_PROCEED_BTN}:${suffix}`)
         .text('\u270F\uFE0F Edit', `${PLAN_EDIT_BTN}:${suffix}`)
         .row()
         .text('\u{1F504} Refresh', `${PLAN_REFRESH_BTN}:${suffix}`)

--- a/tests/services/planningDetector.test.ts
+++ b/tests/services/planningDetector.test.ts
@@ -25,6 +25,9 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         mockCdpService = new MockedCdpService() as jest.Mocked<CdpService>;
         mockCdpService.getPrimaryContextId = jest.fn().mockReturnValue(42);
         jest.clearAllMocks();
+        // start() now captures a DOM baseline before the first poll.
+        // Set up the default mock so baseline call always returns empty counts.
+        mockCdpService.call.mockResolvedValue({ result: { value: { notifyCount: 0, cardCount: 0, iconCount: 0 } } });
     });
 
     afterEach(async () => {
@@ -33,6 +36,9 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         }
         jest.useRealTimers();
     });
+
+    /** Empty baseline response — consumed by the resetBaseline() call inside start() */
+    const BASELINE_RESP = { result: { value: { notifyCount: 0, cardCount: 0, iconCount: 0 } } };
 
     /** Helper to generate PlanningInfo for testing */
     function makePlanningInfo(overrides: Partial<PlanningInfo> = {}): PlanningInfo {
@@ -159,6 +165,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
 
         // detected -> disappear -> re-detected (within cooldown)
         mockCdpService.call
+            .mockResolvedValueOnce(BASELINE_RESP)                              // baseline (from start())
             .mockResolvedValueOnce({ result: { value: mockInfo } })   // detected
             .mockResolvedValueOnce({ result: { value: null } })       // disappear (key reset)
             .mockResolvedValueOnce({ result: { value: mockInfo } });  // re-detected
@@ -365,6 +372,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         const mockInfo = makePlanningInfo();
 
         mockCdpService.call
+            .mockResolvedValueOnce(BASELINE_RESP)                            // baseline (from start())
             .mockResolvedValueOnce({ result: { value: mockInfo } })  // 1st: detected
             .mockResolvedValueOnce({ result: { value: null } });     // 2nd: disappeared
 
@@ -389,6 +397,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         const mockInfo = makePlanningInfo({ openText: 'Open Plan' });
 
         mockCdpService.call
+            .mockResolvedValueOnce(BASELINE_RESP)                                      // baseline (from start())
             .mockResolvedValueOnce({ result: { value: mockInfo } })
             .mockResolvedValueOnce({ result: { value: { ok: true } } });
 
@@ -419,6 +428,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         const mockInfo = makePlanningInfo({ proceedText: 'Start Implementation' });
 
         mockCdpService.call
+            .mockResolvedValueOnce(BASELINE_RESP)                                      // baseline (from start())
             .mockResolvedValueOnce({ result: { value: mockInfo } })
             .mockResolvedValueOnce({ result: { value: { ok: true } } });
 
@@ -533,6 +543,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         const mockInfo = makePlanningInfo();
 
         mockCdpService.call
+            .mockResolvedValueOnce(BASELINE_RESP)                            // baseline (from start())
             .mockResolvedValueOnce({ result: { value: mockInfo } })  // detected
             .mockResolvedValueOnce({ result: { value: null } });     // disappeared
 

--- a/tests/services/responseMonitor.lean.test.ts
+++ b/tests/services/responseMonitor.lean.test.ts
@@ -99,8 +99,9 @@ describe('Lean ResponseMonitor (new API)', () => {
             onPhaseChange: (phase) => { phases.push(phase); },
         });
 
-        // Baseline calls: RESPONSE_TEXT + PROCESS_LOGS in parallel
+        // Baseline calls: 1. Artifact counts, 2. RESPONSE_TEXT, 3. PROCESS_LOGS
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 })) // Artifact counts baseline
             .mockResolvedValueOnce(cdpResult('existing text'))  // RESPONSE_TEXT baseline
             .mockResolvedValueOnce(cdpResult(null));             // PROCESS_LOGS baseline
 
@@ -108,9 +109,9 @@ describe('Lean ResponseMonitor (new API)', () => {
 
         expect(phases).toContain('waiting');
         expect(monitor.getPhase()).toBe('waiting');
-        // Baseline should have been captured via 2 CDP calls:
-        // 1. RESPONSE_TEXT baseline, 2. PROCESS_LOGS baseline
-        expect(cdpService.call).toHaveBeenCalledTimes(2);
+        // Baseline should have been captured via 3 CDP calls:
+        // 1. Artifact counts, 2. RESPONSE_TEXT baseline, 3. PROCESS_LOGS baseline
+        expect(cdpService.call).toHaveBeenCalledTimes(3);
 
         await monitor.stop();
     });
@@ -126,6 +127,7 @@ describe('Lean ResponseMonitor (new API)', () => {
 
         // Baseline: no text
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))   // RESPONSE_TEXT baseline
             .mockResolvedValueOnce(cdpResult(null));   // PROCESS_LOGS baseline
         await monitor.start();
@@ -151,6 +153,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -175,6 +178,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -209,6 +213,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -249,6 +254,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -282,6 +288,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -315,6 +322,7 @@ describe('Lean ResponseMonitor (new API)', () => {
 
         // Baseline captures 'old response'
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult('old response'))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -340,6 +348,7 @@ describe('Lean ResponseMonitor (new API)', () => {
 
         // Baseline captures old response
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult('old response'))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -370,6 +379,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -392,6 +402,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -410,6 +421,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         const monitor = createMonitor();
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -428,6 +440,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         const monitor = createMonitor();
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await monitor.start();
@@ -452,6 +465,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         });
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))
             .mockResolvedValueOnce(cdpResult(null));
         await defaultMonitor.start();
@@ -500,6 +514,7 @@ describe('Lean ResponseMonitor (new API)', () => {
         const monitor = createMonitor();
 
         cdpService.call
+            .mockResolvedValueOnce(cdpResult({ notifyCount: 0, cardCount: 0 }))
             .mockResolvedValueOnce(cdpResult(null))   // baseline text
             .mockResolvedValueOnce(cdpResult(null));   // baseline process_logs
         await monitor.start();

--- a/tests/ui/planUi.test.ts
+++ b/tests/ui/planUi.test.ts
@@ -23,7 +23,7 @@ describe('planUi', () => {
         it('builds notification with all four buttons', () => {
             const { text, keyboard } = buildPlanNotificationUI(info, 'my-project', '12345');
 
-            expect(text).toContain('Planning Mode');
+            expect(text).toContain('Plan Ready');
             expect(text).toContain('refactor-auth.md');
             expect(text).toContain('my-project');
             expect(text).toContain('JWT tokens');
@@ -92,7 +92,7 @@ describe('planUi', () => {
     });
 
     describe('buildPlanContentUI', () => {
-        it('builds single page without navigation buttons', () => {
+        it('builds single page without navigation buttons (no proceedText)', () => {
             const pages = ['Plan content here'];
             const { text, keyboard } = buildPlanContentUI(pages, 0, 'proj', '123');
 
@@ -102,14 +102,25 @@ describe('planUi', () => {
             expect(text).not.toMatch(/\(\d+\/\d+\)/);
 
             const rows = (keyboard as any).inline_keyboard;
-            // Single page: no pagination, but action buttons present
+            // No proceedText → 3 action buttons (Edit, Refresh, View Full)
+            const allButtons = rows.flat();
+            expect(allButtons.length).toBe(3);
+            const cbData = allButtons.map((b: any) => b.callback_data);
+            expect(cbData.some((d: string) => d.includes(PLAN_PROCEED_BTN))).toBe(false);
+            expect(cbData.some((d: string) => d.includes(PLAN_EDIT_BTN))).toBe(true);
+            expect(cbData.some((d: string) => d.includes(PLAN_REFRESH_BTN))).toBe(true);
+            expect(cbData.some((d: string) => d.includes(PLAN_VIEW_BTN))).toBe(true);
+        });
+
+        it('includes Proceed button when proceedText is provided', () => {
+            const pages = ['Plan content here'];
+            const { keyboard } = buildPlanContentUI(pages, 0, 'proj', '123', 'implementation_plan.md', 'Proceed');
+
+            const rows = (keyboard as any).inline_keyboard;
             const allButtons = rows.flat();
             expect(allButtons.length).toBe(4);
             const cbData = allButtons.map((b: any) => b.callback_data);
             expect(cbData.some((d: string) => d.includes(PLAN_PROCEED_BTN))).toBe(true);
-            expect(cbData.some((d: string) => d.includes(PLAN_EDIT_BTN))).toBe(true);
-            expect(cbData.some((d: string) => d.includes(PLAN_REFRESH_BTN))).toBe(true);
-            expect(cbData.some((d: string) => d.includes(PLAN_VIEW_BTN))).toBe(true);
         });
 
         it('builds multi-page with navigation buttons', () => {


### PR DESCRIPTION
## Summary

Fixes implementation plan detection in the Antigravity planning UI — the chip selector was matching no chips at all, and a 5-second cooldown was preventing upgrade notifications from fileRefMode → button-based detection. After a live DOM inspection, the correct CSS classes were confirmed and the full Proceed+Open flow now surfaces correctly in Telegram.

## Related Issues

Closes # [Insert Issue Number if applicable]

## Type of Change

- [x] Bug fix

## What Changed

### Root Cause — Wrong Chip Selector
`ARTIFACT_CHIP_SELECTOR` required `cursor-pointer` as a class fragment on the chip container. Live DOM inspection showed the actual container classes are `border-gray-500/20 … select-none` — **`cursor-pointer` is only on inner elements, not the container.** This meant every pass 1-3 missed every chip, leaving only the 4th-pass (icon-based, `fileRefMode`) detection path active. `fileRefMode` synthesises an `Open` action but has no `proceedText`, so the Telegram notification never showed a Proceed button.

**Fix:** Updated selector to `div[class*="border-gray-500"][class*="select-none"]` — matches the actual DOM.

### Cooldown Upgrade Bypass
When the 4th pass fires first (Files Modified icon renders before the chip expands), the 5-second cooldown blocked the subsequent proper chip detection (different key, but within the window). Added an `isUpgrade` check: if the new detection has a `proceedText` and the previous one was `fileRefMode` or missing a proceed button, the cooldown is bypassed and a corrected notification is sent.

### Baseline Capture on Start
`start()` now asynchronously captures a DOM baseline **before** scheduling the first poll. This prevents pre-existing plan artifacts from previous sessions triggering false notifications on bot restart.

### fileRefMode Wiring (bot + services)
- `bot/index.ts`: `PLAN_PROCEED_BTN` for `fileRefMode` plans submits a synthetic "Proceed" message to the Antigravity chat input instead of clicking a non-existent button.
- `cdpBridgeManager.ts`: added `submitChatMessage()` helper.
- `responseMonitor.ts`: DOM queries are now scoped to the latest message only to prevent stale artifact detection.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the diff
- [x] Added/updated tests for the changes
- [x] `npm test` and `npm run build` pass locally (705 tests, 0 failures)
- [x] Tested manually in Telegram with Antigravity UI.
