### PR TITLE
feat: add /close command to terminate active Antigravity workspace via CDP

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -939,7 +939,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             `/chat — Show current session info\n\n` +
             `<b>⏹️ Control</b>\n` +
             `/stop — Interrupt active LLM generation\n` +
-            `/screenshot — Capture Antigravity screen\n\n` +
+            `/screenshot — Capture Antigravity screen\n` +
+            `/close — Terminate active Antigravity session\n\n` +
             `<b>⚙️ Settings</b>\n` +
             `/mode — Display and change execution mode\n` +
             `/model — Display and change LLM model\n\n` +
@@ -1095,6 +1096,24 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             async (text) => { await ctx.reply(text); },
             getCurrentCdp(bridge),
         );
+    });
+
+    // /close command
+    bot.command('close', async (ctx) => {
+        const ch = getChannel(ctx);
+        const cdp = getCurrentCdp(bridge);
+        if (!cdp) {
+            await ctx.reply('⚠️ No active Antigravity session to close.');
+            return;
+        }
+        const projectName = cdp.getCurrentWorkspaceName();
+        if (!projectName) {
+            await ctx.reply('⚠️ No active project bound to this chat. Cannot close.');
+            return;
+        }
+        await ctx.reply(`🛑 Closing Antigravity workspace: \`${projectName}\`…`);
+        await bridge.pool.closeBrowserWorkspace(projectName);
+        await ctx.reply('✅ Workspace closed. Send a new prompt or use /project to reconnect.');
     });
 
     // /stop command
@@ -1844,7 +1863,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     logger.info('Starting Remoat Telegram bot...');
 
     // Graceful shutdown: close database on exit
-    const closeDb = () => { try { db.close(); } catch { /* ignore */ } };
+    const closeDb = () => { try { db.close(); } catch (e) { logger.debug('[shutdown] db.close() failed:', e); } };
     process.on('exit', closeDb);
     process.on('SIGINT', () => { closeDb(); process.exit(0); });
     process.on('SIGTERM', () => { closeDb(); process.exit(0); });
@@ -1867,6 +1886,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     { command: 'model', description: 'Change LLM model' },
                     { command: 'stop', description: 'Interrupt active generation' },
                     { command: 'screenshot', description: 'Capture Antigravity screen' },
+                    { command: 'close', description: 'Terminate active Antigravity session' },
                     { command: 'template', description: 'Show prompt templates' },
                     { command: 'template_add', description: 'Register a template' },
                     { command: 'template_delete', description: 'Delete a template' },

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1099,21 +1099,28 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     });
 
     // /close command
+    // Note: any active ResponseMonitor polling the closed workspace will encounter
+    // errors until it times out, since the monitor is not pool-managed.
     bot.command('close', async (ctx) => {
         const ch = getChannel(ctx);
-        const cdp = getCurrentCdp(bridge);
+        const resolved = await resolveWorkspaceAndCdp(ch);
+        const cdp = resolved?.cdp ?? getCurrentCdp(bridge);
         if (!cdp) {
             await ctx.reply('⚠️ No active Antigravity session to close.');
             return;
         }
-        const projectName = cdp.getCurrentWorkspaceName();
+        const projectName = resolved?.projectName ?? cdp.getCurrentWorkspaceName();
         if (!projectName) {
             await ctx.reply('⚠️ No active project bound to this chat. Cannot close.');
             return;
         }
-        await ctx.reply(`🛑 Closing Antigravity workspace: \`${projectName}\`…`);
-        await bridge.pool.closeBrowserWorkspace(projectName);
-        await ctx.reply('✅ Workspace closed. Send a new prompt or use /project to reconnect.');
+        try {
+            await replyHtml(ctx, `🛑 Closing Antigravity workspace: <code>${escapeHtml(projectName)}</code>…`);
+            await bridge.pool.closeBrowserWorkspace(projectName);
+            await ctx.reply('✅ Workspace closed. Send a new prompt or use /project to reconnect.');
+        } catch (e: any) {
+            await ctx.reply(`❌ Error closing workspace: ${e.message}`);
+        }
     });
 
     // /stop command

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -133,6 +133,21 @@ export class CdpConnectionPool extends EventEmitter {
     }
 
     /**
+     * Completely close the Antigravity instance for the specified workspace via CDP.
+     */
+    async closeBrowserWorkspace(projectName: string): Promise<void> {
+        const cdp = this.connections.get(projectName);
+        if (cdp) {
+            try {
+                await cdp.closeBrowserTarget();
+            } catch (err) {
+                logger.error(`[CdpConnectionPool] Error while closing browser for ${projectName}:`, err);
+            }
+        }
+        this.disconnectWorkspace(projectName);
+    }
+
+    /**
      * Disconnect all workspace connections.
      */
     disconnectAll(): void {

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -259,6 +259,42 @@ export class CdpService extends EventEmitter {
         });
     }
 
+    /**
+     * Closes the Antigravity instance completely via the CDP HTTP JSON endpoint.
+     */
+    public async closeBrowserTarget(): Promise<void> {
+        if (!this.targetUrl) return;
+
+        const match = this.targetUrl.match(/ws:\/\/(.+?)\/devtools\/page\/(.+)/);
+        if (match) {
+            const hostAndPort = match[1];
+            const targetId = match[2];
+
+            try {
+                // Drop the WebSocket to avoid immediate reconnect cascade during termination
+                await this.disconnect();
+
+                await new Promise<void>((resolve, reject) => {
+                    const req = http.request(`http://${hostAndPort}/json/close/${targetId}`, { method: 'PUT' }, (res) => {
+                        res.resume(); // drain response
+                        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                            resolve();
+                        } else {
+                            reject(new Error(`Close failed with status ${res.statusCode}`));
+                        }
+                    });
+                    req.on('error', reject);
+                    req.end();
+                });
+            } catch (err: any) {
+                logger.error(`[CdpService] Failed to remotely close browser target: ${err.message}`);
+                throw err;
+            }
+        } else {
+            throw new Error('Could not parse target context for closing.');
+        }
+    }
+
     async disconnect(): Promise<void> {
         this.stopHeartbeat();
         // Suppress 'disconnected' event (and reconnect attempts) during intentional shutdown


### PR DESCRIPTION
## Problem

When an Antigravity workspace gets into a bad state (stuck generation, crashed session), the only recovery option was restarting the entire Remoat process — which drops all active connections and chat sessions.

## Solution

Adds a `/close` bot command that uses the CDP JSON HTTP API to kill the specific Chromium target (tab) associated with the current chat's workspace, then cleans up the connection pool entry. This gives users a surgical reset without affecting other workspaces.

### How it works

1. `CdpService.closeBrowserTarget()` — parses the active WebSocket target URL, disconnects cleanly (to prevent reconnect cascades), then fires a `PUT /json/close/<targetId>` HTTP request to the CDP endpoint.
2. `CdpConnectionPool.closeBrowserWorkspace()` — looks up the connection for the named workspace, calls `closeBrowserTarget()`, then removes the entry from the pool via `disconnectWorkspace()`.
3. `bot.command('close')` — validates the session has an active project, calls `pool.closeBrowserWorkspace()`, and sends a confirmation reply.

## Changes

- `src/services/cdpService.ts` — new `closeBrowserTarget()` method
- `src/services/cdpConnectionPool.ts` — new `closeBrowserWorkspace()` method
- `src/bot/index.ts` — `/close` command handler, help text entry, `setMyCommands` registration

## Testing

`npm run build` — clean. `npm test` — all 699 tests pass. Manual verification: `/close` with an active workspace correctly terminates the Chromium target and responds with a confirmation message.
