### PR TITLE
feat: concurrency queue with Queue/Stop-and-Send/Discard interrupt keyboard

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -43,7 +43,6 @@ import {
 import { classifyAssistantSegments, extractAssistantSegmentsPayloadScript } from '../services/assistantDomExtractor';
 import { buildModeModelLines, splitForEmbedDescription } from '../utils/streamMessageFormatter';
 import { formatForTelegram, splitOutputAndLogs, escapeHtml, splitTelegramHtml } from '../utils/telegramFormatter';
-// ProcessLogBuffer no longer used — progress display uses ordered event stream
 import {
     buildPromptWithAttachmentUrls,
     cleanupInboundImageAttachments,
@@ -64,6 +63,23 @@ import {
     PLAN_VIEW_BTN, PLAN_PROCEED_BTN, PLAN_EDIT_BTN, PLAN_REFRESH_BTN, PLAN_PAGE_PREFIX,
     buildPlanNotificationUI, buildPlanContentUI, paginatePlanContent,
 } from '../ui/planUi';
+import {
+    INTERRUPT_QUEUE_PREFIX, INTERRUPT_NOW_PREFIX, INTERRUPT_DISCARD_PREFIX,
+    buildInterruptUI,
+} from '../ui/queueUi';
+import {
+    addPendingInterrupt,
+    getFirstPendingInterrupt,
+    getAllPendingInterrupts,
+    getQueueDepth,
+    shiftPendingInterrupt,
+    drainPendingInterrupts,
+    hasPendingInterrupts,
+    clearPendingInterrupts,
+
+    consumeBypass,
+    MAX_QUEUE_DEPTH,
+} from '../services/interruptState';
 
 const PHASE_ICONS = {
     sending: '📡',
@@ -112,6 +128,9 @@ function stripHtmlForFile(html: string): string {
 }
 
 const userStopRequestedChannels = new Set<string>();
+
+// Interrupt state is managed by ../services/interruptState.ts
+// (addPendingInterrupt, drainPendingInterrupts, etc.)
 
 /** Channels where the user is expected to type plan edit instructions */
 const planEditPendingChannels = new Map<string, { projectName: string }>();
@@ -443,10 +462,17 @@ async function sendPromptToAntigravity(
             const res = await cdp.call('Runtime.evaluate', callParams);
             const value = res?.result?.value;
             return typeof value === 'string' ? value.trim() : '';
-        } catch { return ''; }
+        } catch (e) { logger.debug('[tryEmergencyExtractText] Failed:', e); return ''; }
     };
 
     let monitor: ResponseMonitor | null = null;
+
+    // Completion gate: holds the PromptDispatcher lock until onComplete/onTimeout fires.
+    // Without this, monitor.start() resolves immediately (it schedules polling via setTimeout),
+    // causing the dispatcher to release the lock while Antigravity is still generating —
+    // allowing a second prompt to inject concurrently and produce duplicate responses.
+    let resolveMonitorDone!: () => void;
+    const monitorDone = new Promise<void>(resolve => { resolveMonitorDone = resolve; });
 
     try {
         // Reset PlanningDetector baseline BEFORE injecting the message.
@@ -582,6 +608,7 @@ async function sendPromptToAntigravity(
                 if (wasStoppedByUser) {
                     logger.info(`[sendPrompt:${monitorTraceId}] Stopped by user`);
                     await sendMsg('⏹️ Generation stopped.');
+                    resolveMonitorDone?.();
                     return;
                 }
 
@@ -602,6 +629,7 @@ async function sendPromptToAntigravity(
                                 await api.sendMessage(channel.chatId, payload.text, { parse_mode: 'HTML', message_thread_id: channel.threadId, reply_markup: payload.keyboard });
                             }
                         } catch (e) { logger.error('[Quota] Failed to send model selection UI:', e); }
+                        resolveMonitorDone();
                         return;
                     }
 
@@ -753,7 +781,7 @@ async function sendPromptToAntigravity(
                                         try {
                                             options.topicManager.setChatId(Number(session.channelId.split(':')[0]));
                                             await options.topicManager.renameTopic(threadId, formattedName);
-                                        } catch { /* topic rename optional */ }
+                                        } catch (e) { logger.debug('[Rename] Topic rename optional, failed:', e); }
                                     }
                                     options.chatSessionRepo.updateDisplayName(channelKey(channel), sessionInfo.title);
                                 }
@@ -762,13 +790,13 @@ async function sendPromptToAntigravity(
                     }
 
                     await sendGeneratedImages(finalOutputText || '');
-                } catch (error) { logger.error(`[sendPrompt:${monitorTraceId}] onComplete failed:`, error); }
+                } catch (error) { logger.error(`[sendPrompt:${monitorTraceId}] onComplete failed:`, error); } finally { resolveMonitorDone?.(); }
             },
-            onTimeout: async (lastText) => {
-                isFinalized = true;
-                if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
-                userStopRequestedChannels.delete(channelKey(channel));
+            onTimeout: async (lastText: string) => {
                 try {
+                    isFinalized = true;
+                    if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
+                    userStopRequestedChannels.delete(channelKey(channel));
                     const elapsed = Math.round((Date.now() - startTime) / 1000);
                     const timeoutText = (lastText && lastText.trim().length > 0) ? lastText : lastProgressText;
                     const timeoutIsHtml = monitor!.getLastExtractionSource() === 'structured';
@@ -782,7 +810,7 @@ async function sendPromptToAntigravity(
                     liveActivityUpdateVersion += 1;
                     thinkingActive = false;
                     await setProgressMessage(`<b>${PHASE_ICONS.timeout} ${escapeHtml(modelLabel)} · ${elapsed}s</b>\n\n${buildProgressBody()}`, { expectedVersion: liveActivityUpdateVersion });
-                } catch (error) { logger.error(`[sendPrompt:${monitorTraceId}] onTimeout failed:`, error); }
+                } catch (error) { logger.error(`[sendPrompt:${monitorTraceId}] onTimeout failed:`, error); } finally { resolveMonitorDone?.(); }
             },
         });
 
@@ -793,12 +821,47 @@ async function sendPromptToAntigravity(
             triggerProgressRefresh();
         }, 5000);
 
+        // Hold the PromptDispatcher lock until the monitor fires onComplete or onTimeout.
+        // This prevents a second incoming prompt from injecting while Antigravity is still generating.
+        await monitorDone;
+
     } catch (e: any) {
         isFinalized = true;
         userStopRequestedChannels.delete(channelKey(channel));
         if (elapsedTimer) { clearInterval(elapsedTimer); }
         if (monitor) { await monitor.stop().catch(() => {}); }
+        const resolve = resolveMonitorDone as (() => void) | null;
+        if (resolve) resolve();
         await sendEmbed(`${PHASE_ICONS.error} Error`, t(`Error occurred during processing: ${e.message}`));
+        // Safety: resolve the gate so the dispatcher lock is released on early errors
+        // (e.g., if monitor.start() throws before onComplete/onTimeout ever fires).
+        resolveMonitorDone();
+    }
+
+    // Hold the dispatcher's workspace lock until the monitor finishes.
+    // Without this, sendPromptToAntigravity resolves immediately after
+    // monitor.start() (which only captures baselines and schedules polling),
+    // releasing the lock and allowing concurrent prompts on the same workspace.
+    if (monitorDone) {
+        await monitorDone;
+    }
+
+    // Auto-dispatch any pending interrupt queue items now that the lock is released.
+    // If the user never pressed Queue/Send/Discard, their messages auto-queue here.
+    const wsKey = cdp.getCurrentWorkspaceName() ? `ws:${cdp.getCurrentWorkspaceName()}` : channelKey(channel);
+    if (hasPendingInterrupts(wsKey)) {
+        const pending = drainPendingInterrupts(wsKey);
+        logger.info(`[AutoQueue] Dispatching ${pending.length} pending message(s) for ${wsKey}`);
+        for (const item of pending) {
+            // No bypass needed — lock is already released
+            // We use dynamic import to avoid circular dependency with promptDispatcher
+            // Instead, we re-call sendPromptToAntigravity directly (same call chain as promptDispatcher)
+            sendPromptToAntigravity(
+                bridge, item.channel, item.prompt, item.cdp,
+                modeService, modelService, item.inboundImages,
+                item.options,
+            ).catch((err) => logger.error('[AutoQueue] Dispatch error:', err));
+        }
     }
 }
 
@@ -832,6 +895,33 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         modeService,
         modelService,
         sendPromptImpl: sendPromptToAntigravity,
+        onTaskComplete: (channel, wsKey) => {
+            // Auto-queue fallback: when a task finishes, auto-dispatch any
+            // pending interrupts the user hasn't acted on yet.
+            if (!hasPendingInterrupts(wsKey)) return;
+
+            const queued = drainPendingInterrupts(wsKey);
+            logger.info(`[autoQueue] Task done for ${wsKey} — auto-dispatching ${queued.length} queued message(s)`);
+
+            for (const pending of queued) {
+                // Edit the interrupt keyboard message to show it was auto-queued
+                if (pending.interruptMsgId && bridge.botApi) {
+                    bridge.botApi.editMessageText(
+                        pending.channel.chatId,
+                        pending.interruptMsgId,
+                        '📥 Task finished — sending your queued message…',
+                        { parse_mode: 'HTML' },
+                    ).catch((e: any) => { logger.debug('[autoQueue] editMessage failed:', e); });
+                }
+                promptDispatcher.send({
+                    channel: pending.channel,
+                    prompt: pending.prompt,
+                    cdp: pending.cdp,
+                    inboundImages: pending.inboundImages,
+                    options: pending.options,
+                }).catch((e: any) => { logger.error('[autoQueue] dispatch failed:', e); });
+            }
+        },
     });
 
     const slashCommandHandler = new SlashCommandHandler(templateRepo);
@@ -939,6 +1029,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             `/chat — Show current session info\n\n` +
             `<b>⏹️ Control</b>\n` +
             `/stop — Interrupt active LLM generation\n` +
+            `/close — Terminate active Antigravity session\n` +
             `/screenshot — Capture Antigravity screen\n\n` +
             `<b>⚙️ Settings</b>\n` +
             `/mode — Display and change execution mode\n` +
@@ -1123,6 +1214,26 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         }
     });
 
+    // /close command
+    bot.command('close', async (ctx) => {
+        const ch = getChannel(ctx);
+        const resolved = await resolveWorkspaceAndCdp(ch);
+        const workspacePath = resolved?.workspacePath;
+
+        if (!workspacePath) {
+            await ctx.reply('⚠️ No active project bound to this chat. Cannot close.');
+            return;
+        }
+
+        const projectName = bridge.pool.extractProjectName(workspacePath);
+        
+        try {
+            await bridge.pool.closeBrowserWorkspace(projectName);
+            await replyHtml(ctx, `<b>🛑 Workspace Closed</b>\nThe browser instance for <code>${escapeHtml(projectName)}</code> has been terminated.`);
+        } catch (e: any) {
+            await ctx.reply(`❌ Error closing workspace: ${e.message}`);
+        }
+    });
     // /project command
     bot.command('project', async (ctx) => {
         const workspaces = workspaceService.scanWorkspaces();
@@ -1223,7 +1334,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const { text, keyboard } = await buildModeUI(modeService, { getCurrentCdp: () => getCurrentCdp(bridge) });
             try {
                 await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
-            } catch { /* may fail if unchanged */ }
+            } catch (e) { logger.debug('[modeSelect] editMessageText failed (expected if unchanged):', e); }
             await ctx.answerCallbackQuery({ text: `Mode: ${MODE_DISPLAY_NAMES[selectedMode] || selectedMode}` });
             return;
         }
@@ -1243,7 +1354,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const res = await cdp.setUiModel(modelName);
             if (res.ok) {
                 const payload = await buildModelsUI(cdp, () => bridge.quota.fetchQuota());
-                if (payload) try { await ctx.editMessageText(payload.text, { parse_mode: 'HTML', reply_markup: payload.keyboard }); } catch { }
+                if (payload) try { await ctx.editMessageText(payload.text, { parse_mode: 'HTML', reply_markup: payload.keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: `Model: ${res.model}` });
             } else {
                 await ctx.answerCallbackQuery({ text: res.error || 'Failed to change model.' });
@@ -1256,7 +1367,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const cdp = getCurrentCdp(bridge);
             if (!cdp) { await ctx.answerCallbackQuery({ text: 'Not connected.' }); return; }
             const payload = await buildModelsUI(cdp, () => bridge.quota.fetchQuota());
-            if (payload) try { await ctx.editMessageText(payload.text, { parse_mode: 'HTML', reply_markup: payload.keyboard }); } catch { }
+            if (payload) try { await ctx.editMessageText(payload.text, { parse_mode: 'HTML', reply_markup: payload.keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             await ctx.answerCallbackQuery({ text: 'Refreshed' });
             return;
         }
@@ -1266,7 +1377,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const action = data === AUTOACCEPT_BTN_ON ? 'on' : 'off';
             bridge.autoAccept.handle(action);
             await sendAutoAcceptUI(
-                async (text, keyboard) => { try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch { } },
+                async (text, keyboard) => { try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); } },
                 bridge.autoAccept,
             );
             await ctx.answerCallbackQuery({ text: `Auto-accept: ${action.toUpperCase()}` });
@@ -1275,7 +1386,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
         if (data === AUTOACCEPT_BTN_REFRESH) {
             await sendAutoAcceptUI(
-                async (text, keyboard) => { try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch { } },
+                async (text, keyboard) => { try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); } },
                 bridge.autoAccept,
             );
             await ctx.answerCallbackQuery({ text: 'Refreshed' });
@@ -1346,7 +1457,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             if (!isNaN(page)) {
                 const workspaces = workspaceService.scanWorkspaces();
                 const { text, keyboard } = buildProjectListUI(workspaces, page);
-                try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch { }
+                try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             }
             await ctx.answerCallbackQuery();
             return;
@@ -1363,9 +1474,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             if (!resolved) {
                 const cdp = getCurrentCdp(bridge);
                 if (!cdp) { await ctx.answerCallbackQuery({ text: 'Not connected.' }); return; }
-                await promptDispatcher.send({ channel: ch, prompt: template.prompt, cdp, inboundImages: [], options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator } });
+                promptDispatcher.send({ channel: ch, prompt: template.prompt, cdp, inboundImages: [], options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator } }).catch((e) => logger.error('[template] dispatch failed:', e));
             } else {
-                await promptDispatcher.send({ channel: ch, prompt: template.prompt, cdp: resolved.cdp, inboundImages: [], options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator } });
+                promptDispatcher.send({ channel: ch, prompt: template.prompt, cdp: resolved.cdp, inboundImages: [], options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator } }).catch((e) => logger.error('[template] dispatch failed:', e));
             }
             await ctx.answerCallbackQuery({ text: `Running: ${template.name}` });
             return;
@@ -1406,7 +1517,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             else { success = await detector.denyButton(); actionLabel = 'Deny'; }
 
             if (success) {
-                try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { }
+                try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: `${actionLabel} executed.` });
             } else {
                 await ctx.answerCallbackQuery({ text: 'Button not found.' });
@@ -1444,7 +1555,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 await ctx.answerCallbackQuery({ text: clicked ? 'Opened' : 'Open button not found.' });
             } else {
                 const clicked = await detector.clickProceedButton();
-                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { }
+                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: clicked ? 'Proceeding...' : 'Proceed button not found.' });
             }
             return;
@@ -1491,7 +1602,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const clicked = await detector.clickProceedButton();
             if (clicked) {
                 planEditPendingChannels.delete(channelKey(ch));
-                try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { }
+                try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             }
             await ctx.answerCallbackQuery({ text: clicked ? 'Proceeding...' : 'Proceed button not found.' });
             return;
@@ -1515,7 +1626,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const info = detector.getLastDetectedInfo();
             if (info) {
                 const { text: uiText, keyboard: uiKeyboard } = buildPlanNotificationUI(info, projectName, targetChannelStr || String(ch.chatId));
-                try { await ctx.editMessageText(uiText, { parse_mode: 'HTML', reply_markup: uiKeyboard }); } catch { }
+                try { await ctx.editMessageText(uiText, { parse_mode: 'HTML', reply_markup: uiKeyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             }
             await ctx.answerCallbackQuery({ text: 'Refreshed' });
             return;
@@ -1536,7 +1647,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             const lastInfo = detector?.getLastDetectedInfo();
 
             const { text: pageText, keyboard: pageKeyboard } = buildPlanContentUI(pages, page, projectName, targetChannelStr || String(ch.chatId), lastInfo?.planTitle ?? undefined, lastInfo?.proceedText ?? undefined);
-            try { await ctx.editMessageText(pageText, { parse_mode: 'HTML', reply_markup: pageKeyboard }); } catch { }
+            try { await ctx.editMessageText(pageText, { parse_mode: 'HTML', reply_markup: pageKeyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             await ctx.answerCallbackQuery({ text: `Page ${page + 1}/${pages.length}` });
             return;
         }
@@ -1550,7 +1661,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             if (errorAction.action === 'dismiss') {
                 const clicked = await detector.clickDismissButton();
-                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { }
+                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: clicked ? 'Dismissed' : 'Button not found.' });
             } else if (errorAction.action === 'copy_debug') {
                 const clicked = await detector.clickCopyDebugInfoButton();
@@ -1568,16 +1679,79 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 await ctx.answerCallbackQuery({ text: feedbackText });
             } else {
                 const clicked = await detector.clickRetryButton();
-                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch { }
+                if (clicked) try { await ctx.editMessageReplyMarkup({ reply_markup: undefined }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: clicked ? 'Retrying...' : 'Button not found.' });
             }
+            return;
+        }
+
+        // Interrupt buttons (Queue / Send Now / Discard)
+        if (data.startsWith(INTERRUPT_QUEUE_PREFIX) || data.startsWith(INTERRUPT_NOW_PREFIX) || data.startsWith(INTERRUPT_DISCARD_PREFIX)) {
+            const targetKey = data.startsWith(INTERRUPT_QUEUE_PREFIX)
+                ? data.slice(INTERRUPT_QUEUE_PREFIX.length)
+                : data.startsWith(INTERRUPT_NOW_PREFIX)
+                    ? data.slice(INTERRUPT_NOW_PREFIX.length)
+                    : data.slice(INTERRUPT_DISCARD_PREFIX.length);
+
+            if (data.startsWith(INTERRUPT_DISCARD_PREFIX)) {
+                // Discard the first pending interrupt
+                shiftPendingInterrupt(targetKey);
+                try { await ctx.editMessageText('🗑 Message discarded.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
+                await ctx.answerCallbackQuery({ text: 'Discarded' });
+                return;
+            }
+
+            const pending = shiftPendingInterrupt(targetKey);
+            if (!pending) {
+                try { await ctx.editMessageText('✅ Task finished — your message was already processed.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
+                await ctx.answerCallbackQuery({ text: 'Already processed' });
+                return;
+            }
+
+            if (data.startsWith(INTERRUPT_NOW_PREFIX)) {
+                // Stop current generation, then send the new prompt
+                try { await ctx.editMessageText('⚡ Stopping current task and sending your message…'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
+                await ctx.answerCallbackQuery({ text: 'Stopping & sending...' });
+
+                // Click the stop button in Antigravity
+                try {
+                    const contextId = pending.cdp.getPrimaryContextId();
+                    const callParams: Record<string, unknown> = { expression: RESPONSE_SELECTORS.CLICK_STOP_BUTTON, returnByValue: true, awaitPromise: false };
+                    if (contextId !== null) callParams.contextId = contextId;
+                    await pending.cdp.call('Runtime.evaluate', callParams);
+                    userStopRequestedChannels.add(channelKey(pending.channel));
+                } catch (e) { logger.debug('[interrupt:now] Stop button click failed:', e); }
+
+                // Dispatch — send() chains on the workspace lock automatically;
+                // no bypass needed (bypass is only checked in the text message handler).
+                promptDispatcher.send({
+                    channel: pending.channel,
+                    prompt: pending.prompt,
+                    cdp: pending.cdp,
+                    inboundImages: pending.inboundImages,
+                    options: pending.options,
+                }).catch((e) => { logger.error('[interrupt:now] dispatch failed:', e); });
+                return;
+            }
+
+            // INTERRUPT_QUEUE_PREFIX — queue to run after current task finishes
+            try { await ctx.editMessageText('📥 Message queued — will send after current task.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
+            await ctx.answerCallbackQuery({ text: 'Queued' });
+
+            promptDispatcher.send({
+                channel: pending.channel,
+                prompt: pending.prompt,
+                cdp: pending.cdp,
+                inboundImages: pending.inboundImages,
+                options: pending.options,
+            }).catch((e) => { logger.error('[interrupt:queue] dispatch failed:', e); });
             return;
         }
 
         // Cleanup buttons
         if (data.startsWith(CLEANUP_ARCHIVE_BTN) || data.startsWith(CLEANUP_DELETE_BTN) || data === CLEANUP_CANCEL_BTN) {
             if (data === CLEANUP_CANCEL_BTN) {
-                try { await ctx.editMessageText('Cleanup cancelled.'); } catch { }
+                try { await ctx.editMessageText('Cleanup cancelled.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
                 await ctx.answerCallbackQuery({ text: 'Cancelled' });
                 return;
             }
@@ -1610,10 +1784,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             }
 
             const action = isDelete ? 'deleted' : 'archived';
-            try { await ctx.editMessageText(`✅ Cleanup complete — ${processed} session(s) ${action}.`); } catch { }
+            try { await ctx.editMessageText(`✅ Cleanup complete — ${processed} session(s) ${action}.`); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
             await ctx.answerCallbackQuery({ text: `${processed} session(s) ${action}` });
             return;
         }
+
 
         await ctx.answerCallbackQuery();
     });
@@ -1647,13 +1822,13 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 return;
             }
             await ctx.reply('Sending plan edit...');
-            await promptDispatcher.send({
+            promptDispatcher.send({
                 channel: ch,
                 prompt: editPrompt,
                 cdp,
                 inboundImages: [],
                 options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
-            });
+            }).catch((e) => logger.error('[planEdit] dispatch failed:', e));
             return;
         }
 
@@ -1692,13 +1867,13 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             if (result.prompt) {
                 const cdp = getCurrentCdp(bridge);
                 if (cdp) {
-                    await promptDispatcher.send({
+                    promptDispatcher.send({
                         channel: ch,
                         prompt: result.prompt,
                         cdp,
                         inboundImages: [],
                         options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
-                    });
+                    }).catch((e) => logger.error('[slashCmd] dispatch failed:', e));
                 } else {
                     await ctx.reply('Not connected to CDP. Send a message first to connect to a project.');
                 }
@@ -1713,6 +1888,43 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             return;
         }
 
+        // ── Concurrency gate: check if workspace is busy ────────────────────
+        const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
+        const busy = promptDispatcher.isBusy(ch, resolved.cdp);
+        const bypassed = busy ? consumeBypass(wsKey) : false;
+        logger.info(`[concurrencyGate] wsKey=${wsKey} busy=${busy} bypassed=${bypassed}`);
+        if (busy && !bypassed) {
+            const dispatchOptions = { chatSessionService, chatSessionRepo, topicManager, titleGenerator };
+            const position = addPendingInterrupt(wsKey, {
+                prompt: text,
+                channel: ch,
+                cdp: resolved.cdp,
+                inboundImages: [],
+                options: dispatchOptions,
+            });
+
+            if (position === null) {
+                await ctx.reply(`⚠️ Queue full (${MAX_QUEUE_DEPTH} messages pending). Please wait or /stop the current task.`);
+                return;
+            }
+
+            if (position === 1) {
+                // First in queue — show the interrupt keyboard
+                const { text: uiText, keyboard } = buildInterruptUI(wsKey, text);
+                const sent = await bot.api.sendMessage(ch.chatId, uiText, {
+                    parse_mode: 'HTML',
+                    message_thread_id: ch.threadId,
+                    reply_markup: keyboard,
+                });
+                const pending = getFirstPendingInterrupt(wsKey);
+                if (pending) pending.interruptMsgId = sent.message_id;
+            } else {
+                await ctx.reply(`📥 Message queued (#${position} in line)`);
+            }
+            return;
+        }
+        // ── End concurrency gate ────────────────────────────────────────────
+
         const session = chatSessionRepo.findByChannelId(key);
         if (session?.displayName) {
             registerApprovalSessionChannel(bridge, resolved.projectName, session.displayName, ch);
@@ -1726,19 +1938,22 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             }
         } else if (session && !session.isRenamed) {
             try { await chatSessionService.startNewChat(resolved.cdp); }
-            catch { /* continue anyway */ }
+            catch (e) { logger.debug('[startNewChat] Failed, continuing anyway:', e); }
         }
 
         const userMsgDetector = bridge.pool.getUserMessageDetector?.(resolved.projectName);
         if (userMsgDetector) userMsgDetector.addEchoHash(text);
 
-        await promptDispatcher.send({
+        // Fire-and-forget: do NOT await so Grammy can process the next update immediately.
+        // The lock is set synchronously inside send() before its first await,
+        // so isBusy() will see it when the next message handler runs.
+        promptDispatcher.send({
             channel: ch,
             prompt: text,
             cdp: resolved.cdp,
             inboundImages: [],
             options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
-        });
+        }).catch((e) => logger.error('[textMsg] dispatch failed:', e));
     });
 
     // Photo message handler
@@ -1760,17 +1975,48 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             String(ctx.message.message_id),
         );
 
-        try {
-            await promptDispatcher.send({
-                channel: ch,
+        // ── Concurrency gate ────────────────────────────────────────────────
+        const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
+        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(wsKey)) {
+            const position = addPendingInterrupt(wsKey, {
                 prompt: caption,
+                channel: ch,
                 cdp: resolved.cdp,
                 inboundImages,
                 options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
             });
-        } finally {
-            await cleanupInboundImageAttachments(inboundImages);
+
+            if (position === null) {
+                await cleanupInboundImageAttachments(inboundImages);
+                await ctx.reply(`⚠️ Queue full (${MAX_QUEUE_DEPTH} messages pending). Please wait or /stop the current task.`);
+                return;
+            }
+
+            if (position === 1) {
+                const keyboard = new InlineKeyboard()
+                    .text('📥 Queue', `interrupt:queue:${wsKey}`)
+                    .text('⚡ Stop & Send Now', `interrupt:now:${wsKey}`)
+                    .text('🗑 Discard', `interrupt:discard:${wsKey}`);
+                await replyHtml(ctx,
+                    `⏳ <b>AI is still generating a response…</b>\n\n🖼️ Photo message queued.`,
+                    keyboard,
+                );
+            } else {
+                await ctx.reply(`📥 Photo message queued (#${position} in line)`);
+            }
+            return; // Images kept in interruptState; cleaned up on dispatch or discard
         }
+        // ── End concurrency gate ────────────────────────────────────────────
+
+        // Fire-and-forget; cleanup images after dispatch completes (not immediately)
+        promptDispatcher.send({
+            channel: ch,
+            prompt: caption,
+            cdp: resolved.cdp,
+            inboundImages,
+            options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
+        }).catch((e) => logger.error('[photoMsg] dispatch failed:', e))
+         .finally(() => cleanupInboundImageAttachments(inboundImages).catch(() => {}));
     });
 
     // Voice message handler (voice-to-prompt via local Whisper transcription)
@@ -1815,13 +2061,13 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             if (result.prompt) {
                 const cdp = getCurrentCdp(bridge);
                 if (cdp) {
-                    await promptDispatcher.send({
+                    promptDispatcher.send({
                         channel: ch,
                         prompt: result.prompt,
                         cdp,
                         inboundImages: [],
                         options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
-                    });
+                    }).catch((e) => logger.error('[voiceCmd] dispatch failed:', e));
                 }
             }
             return;
@@ -1829,22 +2075,56 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
         await ctx.reply(`📝 "${transcript}"`);
 
+        // ── Concurrency gate ────────────────────────────────────────────────
+        const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
+        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(wsKey)) {
+            const position = addPendingInterrupt(wsKey, {
+                prompt: transcript,
+                channel: ch,
+                cdp: resolved.cdp,
+                inboundImages: [],
+                options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
+            });
+
+            if (position === null) {
+                await ctx.reply(`⚠️ Queue full (${MAX_QUEUE_DEPTH} messages pending). Please wait or /stop the current task.`);
+                return;
+            }
+
+            if (position === 1) {
+                const keyboard = new InlineKeyboard()
+                    .text('📥 Queue', `interrupt:queue:${wsKey}`)
+                    .text('⚡ Stop & Send Now', `interrupt:now:${wsKey}`)
+                    .text('🗑 Discard', `interrupt:discard:${wsKey}`);
+                const preview = transcript.length > 80 ? transcript.slice(0, 77) + '…' : transcript;
+                await replyHtml(ctx,
+                    `⏳ <b>AI is still generating a response…</b>\n\n🎙️ Voice: <i>${escapeHtml(preview)}</i>`,
+                    keyboard,
+                );
+            } else {
+                await ctx.reply(`📥 Voice message queued (#${position} in line)`);
+            }
+            return;
+        }
+        // ── End concurrency gate ────────────────────────────────────────────
+
         const userMsgDetector = bridge.pool.getUserMessageDetector?.(resolved.projectName);
         if (userMsgDetector) userMsgDetector.addEchoHash(transcript);
 
-        await promptDispatcher.send({
+        // Fire-and-forget: same pattern as text handler
+        promptDispatcher.send({
             channel: ch,
             prompt: transcript,
             cdp: resolved.cdp,
             inboundImages: [],
             options: { chatSessionService, chatSessionRepo, topicManager, titleGenerator },
-        });
+        }).catch((e) => logger.error('[voiceMsg] dispatch failed:', e));
     });
 
     logger.info('Starting Remoat Telegram bot...');
 
     // Graceful shutdown: close database on exit
-    const closeDb = () => { try { db.close(); } catch { /* ignore */ } };
+    const closeDb = () => { try { db.close(); } catch (e) { logger.debug('[shutdown] db.close() failed:', e); } };
     process.on('exit', closeDb);
     process.on('SIGINT', () => { closeDb(); process.exit(0); });
     process.on('SIGTERM', () => { closeDb(); process.exit(0); });
@@ -1866,6 +2146,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     { command: 'mode', description: 'Change execution mode' },
                     { command: 'model', description: 'Change LLM model' },
                     { command: 'stop', description: 'Interrupt active generation' },
+                    { command: 'close', description: 'Terminate active Antigravity session' },
                     { command: 'screenshot', description: 'Capture Antigravity screen' },
                     { command: 'template', description: 'Show prompt templates' },
                     { command: 'template_add', description: 'Register a template' },

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -65,18 +65,14 @@ import {
 } from '../ui/planUi';
 import {
     INTERRUPT_QUEUE_PREFIX, INTERRUPT_NOW_PREFIX, INTERRUPT_DISCARD_PREFIX,
-    buildInterruptUI,
+    buildInterruptUI, safeCallbackKey,
 } from '../ui/queueUi';
 import {
     addPendingInterrupt,
     getFirstPendingInterrupt,
-    getAllPendingInterrupts,
-    getQueueDepth,
     shiftPendingInterrupt,
     drainPendingInterrupts,
     hasPendingInterrupts,
-    clearPendingInterrupts,
-
     consumeBypass,
     MAX_QUEUE_DEPTH,
 } from '../services/interruptState';
@@ -830,38 +826,8 @@ async function sendPromptToAntigravity(
         userStopRequestedChannels.delete(channelKey(channel));
         if (elapsedTimer) { clearInterval(elapsedTimer); }
         if (monitor) { await monitor.stop().catch(() => {}); }
-        const resolve = resolveMonitorDone as (() => void) | null;
-        if (resolve) resolve();
-        await sendEmbed(`${PHASE_ICONS.error} Error`, t(`Error occurred during processing: ${e.message}`));
-        // Safety: resolve the gate so the dispatcher lock is released on early errors
-        // (e.g., if monitor.start() throws before onComplete/onTimeout ever fires).
         resolveMonitorDone();
-    }
-
-    // Hold the dispatcher's workspace lock until the monitor finishes.
-    // Without this, sendPromptToAntigravity resolves immediately after
-    // monitor.start() (which only captures baselines and schedules polling),
-    // releasing the lock and allowing concurrent prompts on the same workspace.
-    if (monitorDone) {
-        await monitorDone;
-    }
-
-    // Auto-dispatch any pending interrupt queue items now that the lock is released.
-    // If the user never pressed Queue/Send/Discard, their messages auto-queue here.
-    const wsKey = cdp.getCurrentWorkspaceName() ? `ws:${cdp.getCurrentWorkspaceName()}` : channelKey(channel);
-    if (hasPendingInterrupts(wsKey)) {
-        const pending = drainPendingInterrupts(wsKey);
-        logger.info(`[AutoQueue] Dispatching ${pending.length} pending message(s) for ${wsKey}`);
-        for (const item of pending) {
-            // No bypass needed — lock is already released
-            // We use dynamic import to avoid circular dependency with promptDispatcher
-            // Instead, we re-call sendPromptToAntigravity directly (same call chain as promptDispatcher)
-            sendPromptToAntigravity(
-                bridge, item.channel, item.prompt, item.cdp,
-                modeService, modelService, item.inboundImages,
-                item.options,
-            ).catch((err) => logger.error('[AutoQueue] Dispatch error:', err));
-        }
+        await sendEmbed(`${PHASE_ICONS.error} Error`, t(`Error occurred during processing: ${e.message}`));
     }
 }
 
@@ -898,12 +864,27 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         onTaskComplete: (channel, wsKey) => {
             // Auto-queue fallback: when a task finishes, auto-dispatch any
             // pending interrupts the user hasn't acted on yet.
-            if (!hasPendingInterrupts(wsKey)) return;
+            // Interrupt state uses safeCallbackKey-truncated keys, so match that here.
+            const interruptKey = safeCallbackKey(wsKey);
+            if (!hasPendingInterrupts(interruptKey)) return;
 
-            const queued = drainPendingInterrupts(wsKey);
+            const queued = drainPendingInterrupts(interruptKey);
             logger.info(`[autoQueue] Task done for ${wsKey} — auto-dispatching ${queued.length} queued message(s)`);
 
+            // Extract project name from wsKey (format: "ws:{projectName}" or channel key)
+            const projectName = wsKey.startsWith('ws:') ? wsKey.slice(3) : null;
+
             for (const pending of queued) {
+                // Re-resolve CDP from pool to avoid stale references
+                const freshCdp = projectName ? bridge.pool.getConnected(projectName) : null;
+                if (!freshCdp) {
+                    logger.warn(`[autoQueue] Workspace ${wsKey} no longer connected, discarding queued message`);
+                    if (pending.inboundImages?.length) {
+                        cleanupInboundImageAttachments(pending.inboundImages).catch(() => {});
+                    }
+                    continue;
+                }
+
                 // Edit the interrupt keyboard message to show it was auto-queued
                 if (pending.interruptMsgId && bridge.botApi) {
                     bridge.botApi.editMessageText(
@@ -916,7 +897,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 promptDispatcher.send({
                     channel: pending.channel,
                     prompt: pending.prompt,
-                    cdp: pending.cdp,
+                    cdp: freshCdp,
                     inboundImages: pending.inboundImages,
                     options: pending.options,
                 }).catch((e: any) => { logger.error('[autoQueue] dispatch failed:', e); });
@@ -1029,7 +1010,6 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             `/chat — Show current session info\n\n` +
             `<b>⏹️ Control</b>\n` +
             `/stop — Interrupt active LLM generation\n` +
-            `/close — Terminate active Antigravity session\n` +
             `/screenshot — Capture Antigravity screen\n\n` +
             `<b>⚙️ Settings</b>\n` +
             `/mode — Display and change execution mode\n` +
@@ -1214,26 +1194,6 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         }
     });
 
-    // /close command
-    bot.command('close', async (ctx) => {
-        const ch = getChannel(ctx);
-        const resolved = await resolveWorkspaceAndCdp(ch);
-        const workspacePath = resolved?.workspacePath;
-
-        if (!workspacePath) {
-            await ctx.reply('⚠️ No active project bound to this chat. Cannot close.');
-            return;
-        }
-
-        const projectName = bridge.pool.extractProjectName(workspacePath);
-        
-        try {
-            await bridge.pool.closeBrowserWorkspace(projectName);
-            await replyHtml(ctx, `<b>🛑 Workspace Closed</b>\nThe browser instance for <code>${escapeHtml(projectName)}</code> has been terminated.`);
-        } catch (e: any) {
-            await ctx.reply(`❌ Error closing workspace: ${e.message}`);
-        }
-    });
     // /project command
     bot.command('project', async (ctx) => {
         const workspaces = workspaceService.scanWorkspaces();
@@ -1694,8 +1654,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     : data.slice(INTERRUPT_DISCARD_PREFIX.length);
 
             if (data.startsWith(INTERRUPT_DISCARD_PREFIX)) {
-                // Discard the first pending interrupt
-                shiftPendingInterrupt(targetKey);
+                // Discard the first pending interrupt and clean up any attached images
+                const discarded = shiftPendingInterrupt(targetKey);
+                if (discarded?.inboundImages?.length) {
+                    cleanupInboundImageAttachments(discarded.inboundImages).catch(() => {});
+                }
                 try { await ctx.editMessageText('🗑 Message discarded.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
                 await ctx.answerCallbackQuery({ text: 'Discarded' });
                 return;
@@ -1708,12 +1671,17 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 return;
             }
 
+            // Re-resolve CDP from pool to avoid dispatching with a stale reference.
+            // For the stop-button click we still use pending.cdp (it targets the running session).
+            const projectName = targetKey.startsWith('ws:') ? targetKey.slice(3) : null;
+            const freshCdp = projectName ? bridge.pool.getConnected(projectName) : null;
+
             if (data.startsWith(INTERRUPT_NOW_PREFIX)) {
                 // Stop current generation, then send the new prompt
                 try { await ctx.editMessageText('⚡ Stopping current task and sending your message…'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
                 await ctx.answerCallbackQuery({ text: 'Stopping & sending...' });
 
-                // Click the stop button in Antigravity
+                // Click the stop button in Antigravity (use pending.cdp — it targets the running session)
                 try {
                     const contextId = pending.cdp.getPrimaryContextId();
                     const callParams: Record<string, unknown> = { expression: RESPONSE_SELECTORS.CLICK_STOP_BUTTON, returnByValue: true, awaitPromise: false };
@@ -1722,12 +1690,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     userStopRequestedChannels.add(channelKey(pending.channel));
                 } catch (e) { logger.debug('[interrupt:now] Stop button click failed:', e); }
 
-                // Dispatch — send() chains on the workspace lock automatically;
-                // no bypass needed (bypass is only checked in the text message handler).
+                const dispatchCdp = freshCdp ?? pending.cdp;
                 promptDispatcher.send({
                     channel: pending.channel,
                     prompt: pending.prompt,
-                    cdp: pending.cdp,
+                    cdp: dispatchCdp,
                     inboundImages: pending.inboundImages,
                     options: pending.options,
                 }).catch((e) => { logger.error('[interrupt:now] dispatch failed:', e); });
@@ -1738,10 +1705,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             try { await ctx.editMessageText('📥 Message queued — will send after current task.'); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
             await ctx.answerCallbackQuery({ text: 'Queued' });
 
+            const dispatchCdp = freshCdp ?? pending.cdp;
             promptDispatcher.send({
                 channel: pending.channel,
                 prompt: pending.prompt,
-                cdp: pending.cdp,
+                cdp: dispatchCdp,
                 inboundImages: pending.inboundImages,
                 options: pending.options,
             }).catch((e) => { logger.error('[interrupt:queue] dispatch failed:', e); });
@@ -1890,12 +1858,13 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
         // ── Concurrency gate: check if workspace is busy ────────────────────
         const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
+        const interruptKey = safeCallbackKey(wsKey);
         const busy = promptDispatcher.isBusy(ch, resolved.cdp);
-        const bypassed = busy ? consumeBypass(wsKey) : false;
+        const bypassed = busy ? consumeBypass(interruptKey) : false;
         logger.info(`[concurrencyGate] wsKey=${wsKey} busy=${busy} bypassed=${bypassed}`);
         if (busy && !bypassed) {
             const dispatchOptions = { chatSessionService, chatSessionRepo, topicManager, titleGenerator };
-            const position = addPendingInterrupt(wsKey, {
+            const position = addPendingInterrupt(interruptKey, {
                 prompt: text,
                 channel: ch,
                 cdp: resolved.cdp,
@@ -1910,13 +1879,13 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             if (position === 1) {
                 // First in queue — show the interrupt keyboard
-                const { text: uiText, keyboard } = buildInterruptUI(wsKey, text);
+                const { text: uiText, keyboard } = buildInterruptUI(interruptKey, text);
                 const sent = await bot.api.sendMessage(ch.chatId, uiText, {
                     parse_mode: 'HTML',
                     message_thread_id: ch.threadId,
                     reply_markup: keyboard,
                 });
-                const pending = getFirstPendingInterrupt(wsKey);
+                const pending = getFirstPendingInterrupt(interruptKey);
                 if (pending) pending.interruptMsgId = sent.message_id;
             } else {
                 await ctx.reply(`📥 Message queued (#${position} in line)`);
@@ -1977,8 +1946,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
         // ── Concurrency gate ────────────────────────────────────────────────
         const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
-        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(wsKey)) {
-            const position = addPendingInterrupt(wsKey, {
+        const interruptKey = safeCallbackKey(wsKey);
+        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(interruptKey)) {
+            const position = addPendingInterrupt(interruptKey, {
                 prompt: caption,
                 channel: ch,
                 cdp: resolved.cdp,
@@ -1994,9 +1964,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             if (position === 1) {
                 const keyboard = new InlineKeyboard()
-                    .text('📥 Queue', `interrupt:queue:${wsKey}`)
-                    .text('⚡ Stop & Send Now', `interrupt:now:${wsKey}`)
-                    .text('🗑 Discard', `interrupt:discard:${wsKey}`);
+                    .text('📥 Queue', `interrupt:queue:${interruptKey}`)
+                    .text('⚡ Stop & Send Now', `interrupt:now:${interruptKey}`)
+                    .text('🗑 Discard', `interrupt:discard:${interruptKey}`);
                 await replyHtml(ctx,
                     `⏳ <b>AI is still generating a response…</b>\n\n🖼️ Photo message queued.`,
                     keyboard,
@@ -2077,8 +2047,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
         // ── Concurrency gate ────────────────────────────────────────────────
         const wsKey = promptDispatcher.getWorkspaceKey(ch, resolved.cdp);
-        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(wsKey)) {
-            const position = addPendingInterrupt(wsKey, {
+        const interruptKey = safeCallbackKey(wsKey);
+        if (promptDispatcher.isBusy(ch, resolved.cdp) && !consumeBypass(interruptKey)) {
+            const position = addPendingInterrupt(interruptKey, {
                 prompt: transcript,
                 channel: ch,
                 cdp: resolved.cdp,
@@ -2093,9 +2064,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             if (position === 1) {
                 const keyboard = new InlineKeyboard()
-                    .text('📥 Queue', `interrupt:queue:${wsKey}`)
-                    .text('⚡ Stop & Send Now', `interrupt:now:${wsKey}`)
-                    .text('🗑 Discard', `interrupt:discard:${wsKey}`);
+                    .text('📥 Queue', `interrupt:queue:${interruptKey}`)
+                    .text('⚡ Stop & Send Now', `interrupt:now:${interruptKey}`)
+                    .text('🗑 Discard', `interrupt:discard:${interruptKey}`);
                 const preview = transcript.length > 80 ? transcript.slice(0, 77) + '…' : transcript;
                 await replyHtml(ctx,
                     `⏳ <b>AI is still generating a response…</b>\n\n🎙️ Voice: <i>${escapeHtml(preview)}</i>`,
@@ -2146,7 +2117,6 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     { command: 'mode', description: 'Change execution mode' },
                     { command: 'model', description: 'Change LLM model' },
                     { command: 'stop', description: 'Interrupt active generation' },
-                    { command: 'close', description: 'Terminate active Antigravity session' },
                     { command: 'screenshot', description: 'Capture Antigravity screen' },
                     { command: 'template', description: 'Show prompt templates' },
                     { command: 'template_add', description: 'Register a template' },

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -53,9 +53,8 @@ export class CdpConnectionPool extends EventEmitter {
                     // Re-validate that the still-open window is actually bound to this workspace.
                     await existing.discoverAndConnectForWorkspace(workspacePath);
                     return existing;
-                } catch (e) {
+                } catch {
                     // Connection dropped during re-validation; close WebSocket and clean up
-                    logger.debug('[CdpConnectionPool] Re-validation failed, cleaning up connection:', e);
                     existing.disconnect().catch(() => {});
                     this.connections.delete(projectName);
                 }
@@ -130,21 +129,6 @@ export class CdpConnectionPool extends EventEmitter {
             userMsgDetector.stop();
             this.userMessageDetectors.delete(projectName);
         }
-    }
-
-    /**
-     * Completely close the Antigravity instance for the specified workspace via CDP.
-     */
-    async closeBrowserWorkspace(projectName: string): Promise<void> {
-        const cdp = this.connections.get(projectName);
-        if (cdp) {
-            try {
-                await cdp.closeBrowserTarget();
-            } catch (err) {
-                logger.error(`[CdpConnectionPool] Error while closing browser for ${projectName}:`, err);
-            }
-        }
-        this.disconnectWorkspace(projectName);
     }
 
     /**

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -133,6 +133,21 @@ export class CdpConnectionPool extends EventEmitter {
     }
 
     /**
+     * Completely close the Antigravity instance for the specified workspace via CDP.
+     */
+    async closeBrowserWorkspace(projectName: string): Promise<void> {
+        const cdp = this.connections.get(projectName);
+        if (cdp) {
+            try {
+                await cdp.closeBrowserTarget();
+            } catch (err) {
+                logger.error(`[CdpConnectionPool] Error while closing browser for ${projectName}:`, err);
+            }
+        }
+        this.disconnectWorkspace(projectName);
+    }
+
+    /**
      * Disconnect all workspace connections.
      */
     disconnectAll(): void {

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -259,6 +259,42 @@ export class CdpService extends EventEmitter {
         });
     }
 
+    /**
+     * Closes the Antigravity instance completely via the CDP HTTP JSON endpoint.
+     */
+    public async closeBrowserTarget(): Promise<void> {
+        if (!this.targetUrl) return;
+
+        const match = this.targetUrl.match(/ws:\/\/(.+?)\/devtools\/page\/(.+)/);
+        if (match) {
+            const hostAndPort = match[1];
+            const targetId = match[2];
+
+            try {
+                // Drop the WebSocket to avoid immediate reconnect cascade during termination
+                await this.disconnect();
+
+                await new Promise<void>((resolve, reject) => {
+                    const req = http.request(`http://${hostAndPort}/json/close/${targetId}`, { method: 'PUT' }, (res) => {
+                        res.resume(); // drain response
+                        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+                            resolve();
+                        } else {
+                            reject(new Error(`Close failed with status ${res.statusCode}`));
+                        }
+                    });
+                    req.on('error', reject);
+                    req.end();
+                });
+            } catch (err: any) {
+                logger.error(`[CdpService] Failed to remotely close browser target: ${err.message}`);
+                throw err;
+            }
+        } else {
+            throw new Error('Could not parse target context for closing.');
+        }
+    }
+
     async disconnect(): Promise<void> {
         this.stopHeartbeat();
         // Suppress 'disconnected' event (and reconnect attempts) during intentional shutdown

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -259,42 +259,6 @@ export class CdpService extends EventEmitter {
         });
     }
 
-    /**
-     * Closes the Antigravity instance completely via the CDP HTTP JSON endpoint.
-     */
-    public async closeBrowserTarget(): Promise<void> {
-        if (!this.targetUrl) return;
-
-        const match = this.targetUrl.match(/ws:\/\/(.+?)\/devtools\/page\/(.+)/);
-        if (match) {
-            const hostAndPort = match[1];
-            const targetId = match[2];
-
-            try {
-                // Drop the WebSocket to avoid immediate reconnect cascade during termination
-                await this.disconnect();
-
-                await new Promise<void>((resolve, reject) => {
-                    const req = http.request(`http://${hostAndPort}/json/close/${targetId}`, { method: 'PUT' }, (res) => {
-                        res.resume(); // drain response
-                        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-                            resolve();
-                        } else {
-                            reject(new Error(`Close failed with status ${res.statusCode}`));
-                        }
-                    });
-                    req.on('error', reject);
-                    req.end();
-                });
-            } catch (err: any) {
-                logger.error(`[CdpService] Failed to remotely close browser target: ${err.message}`);
-                throw err;
-            }
-        } else {
-            throw new Error('Could not parse target context for closing.');
-        }
-    }
-
     async disconnect(): Promise<void> {
         this.stopHeartbeat();
         // Suppress 'disconnected' event (and reconnect attempts) during intentional shutdown

--- a/src/services/interruptState.ts
+++ b/src/services/interruptState.ts
@@ -158,22 +158,8 @@ export function clearPendingInterrupts(wsKey: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Mark a workspace key to bypass the busy check on next dispatch.
- */
-export function addBypass(wsKey: string): void {
-    bypassBusyCheck.add(wsKey);
-}
-
-/**
  * Check and consume a bypass flag. Returns true if the bypass was set.
  */
 export function consumeBypass(wsKey: string): boolean {
     return bypassBusyCheck.delete(wsKey);
-}
-
-/**
- * Check if a bypass is set (without consuming it).
- */
-export function hasBypass(wsKey: string): boolean {
-    return bypassBusyCheck.has(wsKey);
 }

--- a/src/services/interruptState.ts
+++ b/src/services/interruptState.ts
@@ -1,0 +1,179 @@
+/**
+ * Interrupt state management for Telegram concurrency queue.
+ *
+ * When a user sends a message while the AI is still generating, we store
+ * the pending request here and show an inline keyboard.  Only the first
+ * pending message gets the keyboard; messages 2–3 auto-queue silently.
+ *
+ * Inspired by cc-claw's pendingInterrupts / bypassBusyCheck pattern.
+ */
+
+import type { TelegramChannel } from './cdpBridgeManager';
+import type { CdpService } from './cdpService';
+import type { PromptDispatchOptions } from './promptDispatcher';
+import type { InboundImageAttachment } from '../utils/imageHandler';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PendingInterrupt {
+    /** The user's prompt text */
+    prompt: string;
+    /** Telegram channel (chatId + threadId) */
+    channel: TelegramChannel;
+    /** CDP service for the target workspace */
+    cdp: CdpService;
+    /** Images attached to the message */
+    inboundImages: InboundImageAttachment[];
+    /** Dispatch options (session service, etc.) */
+    options?: PromptDispatchOptions;
+    /** Position in queue (1 = first / has keyboard) */
+    position: number;
+    /** Timestamp when the interrupt was created */
+    createdAt: number;
+    /** Telegram message ID of the interrupt keyboard message (position=1 only) */
+    interruptMsgId?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Maximum number of pending messages per workspace. */
+export const MAX_QUEUE_DEPTH = 3;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+/**
+ * Pending interrupts keyed by workspace key.
+ * Each workspace has an ordered array of up to MAX_QUEUE_DEPTH items.
+ */
+const pendingInterrupts = new Map<string, PendingInterrupt[]>();
+
+/**
+ * Workspace keys that should bypass the busy check on their next dispatch.
+ * Set when the user taps Queue or Send Now; consumed by the message handler.
+ */
+const bypassBusyCheck = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Accessors
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a pending interrupt for a workspace.
+ * Returns the position in queue (1-based) or null if the queue is full.
+ */
+export function addPendingInterrupt(wsKey: string, interrupt: Omit<PendingInterrupt, 'position' | 'createdAt'>): number | null {
+    const queue = pendingInterrupts.get(wsKey) ?? [];
+
+    if (queue.length >= MAX_QUEUE_DEPTH) {
+        return null; // Queue full
+    }
+
+    const position = queue.length + 1;
+    queue.push({
+        ...interrupt,
+        position,
+        createdAt: Date.now(),
+    });
+    pendingInterrupts.set(wsKey, queue);
+    return position;
+}
+
+/**
+ * Get the first (keyboard-holding) pending interrupt for a workspace.
+ */
+export function getFirstPendingInterrupt(wsKey: string): PendingInterrupt | undefined {
+    const queue = pendingInterrupts.get(wsKey);
+    return queue?.[0];
+}
+
+/**
+ * Get all pending interrupts for a workspace (ordered).
+ */
+export function getAllPendingInterrupts(wsKey: string): PendingInterrupt[] {
+    return pendingInterrupts.get(wsKey) ?? [];
+}
+
+/**
+ * Get the queue depth for a workspace.
+ */
+export function getQueueDepth(wsKey: string): number {
+    return pendingInterrupts.get(wsKey)?.length ?? 0;
+}
+
+/**
+ * Remove and return the first pending interrupt (the one with the keyboard).
+ * Remaining items stay in the queue with positions renumbered.
+ */
+export function shiftPendingInterrupt(wsKey: string): PendingInterrupt | undefined {
+    const queue = pendingInterrupts.get(wsKey);
+    if (!queue || queue.length === 0) return undefined;
+
+    const first = queue.shift()!;
+
+    // Renumber remaining items
+    for (let i = 0; i < queue.length; i++) {
+        queue[i].position = i + 1;
+    }
+
+    if (queue.length === 0) {
+        pendingInterrupts.delete(wsKey);
+    }
+
+    return first;
+}
+
+/**
+ * Remove and return ALL pending interrupts for a workspace.
+ * Used when dispatching the entire queue (Queue / Send Now).
+ */
+export function drainPendingInterrupts(wsKey: string): PendingInterrupt[] {
+    const queue = pendingInterrupts.get(wsKey) ?? [];
+    pendingInterrupts.delete(wsKey);
+    return queue;
+}
+
+/**
+ * Check if a workspace has any pending interrupts.
+ */
+export function hasPendingInterrupts(wsKey: string): boolean {
+    const queue = pendingInterrupts.get(wsKey);
+    return !!queue && queue.length > 0;
+}
+
+/**
+ * Clear all pending interrupts for a workspace (used on discard-all or cleanup).
+ */
+export function clearPendingInterrupts(wsKey: string): void {
+    pendingInterrupts.delete(wsKey);
+}
+
+// ---------------------------------------------------------------------------
+// Bypass management
+// ---------------------------------------------------------------------------
+
+/**
+ * Mark a workspace key to bypass the busy check on next dispatch.
+ */
+export function addBypass(wsKey: string): void {
+    bypassBusyCheck.add(wsKey);
+}
+
+/**
+ * Check and consume a bypass flag. Returns true if the bypass was set.
+ */
+export function consumeBypass(wsKey: string): boolean {
+    return bypassBusyCheck.delete(wsKey);
+}
+
+/**
+ * Check if a bypass is set (without consuming it).
+ */
+export function hasBypass(wsKey: string): boolean {
+    return bypassBusyCheck.has(wsKey);
+}

--- a/src/services/promptDispatcher.ts
+++ b/src/services/promptDispatcher.ts
@@ -1,4 +1,5 @@
 import { ChatSessionRepository } from '../database/chatSessionRepository';
+import { logger } from '../utils/logger';
 import { CdpBridge, TelegramChannel } from './cdpBridgeManager';
 import { CdpService } from './cdpService';
 import { ModeService } from './modeService';
@@ -37,6 +38,8 @@ export interface PromptDispatcherDeps {
         inboundImages?: InboundImageAttachment[],
         options?: PromptDispatchOptions,
     ) => Promise<void>;
+    /** Called after each task completes (success or error). Used for auto-queue fallback. */
+    onTaskComplete?: (channel: TelegramChannel, wsKey: string) => void;
 }
 
 export class PromptDispatcher {
@@ -49,6 +52,26 @@ export class PromptDispatcher {
 
     private channelKey(ch: TelegramChannel): string {
         return ch.threadId ? `${ch.chatId}:${ch.threadId}` : String(ch.chatId);
+    }
+
+    /**
+     * Resolve the workspace lock key for a channel + cdp pair.
+     * Exposed so the interrupt state module can use the same key.
+     */
+    getWorkspaceKey(ch: TelegramChannel, cdp: CdpService): string {
+        const wsName = cdp.getCurrentWorkspaceName();
+        return wsName ? `ws:${wsName}` : this.channelKey(ch);
+    }
+
+    /**
+     * Check if a workspace is currently processing a prompt.
+     * Returns true when a workspace lock is held (generation in progress).
+     */
+    isBusy(ch: TelegramChannel, cdp: CdpService): boolean {
+        const lockKey = this.getWorkspaceKey(ch, cdp);
+        const busy = this.workspaceLocks.has(lockKey);
+        logger.debug(`[PromptDispatcher] isBusy(${lockKey}) = ${busy} (locks: ${this.workspaceLocks.size})`);
+        return busy;
     }
 
     async send(req: PromptDispatchRequest): Promise<void> {
@@ -74,6 +97,7 @@ export class PromptDispatcher {
         ).catch(() => { /* errors handled inside sendPromptImpl */ });
 
         this.workspaceLocks.set(lockKey, current);
+        logger.debug(`[PromptDispatcher] Lock ACQUIRED: ${lockKey} (total: ${this.workspaceLocks.size})`);
         // Also keep per-channel entry so callers that check channel ordering still work
         this.channelLocks.set(chKey, current);
 
@@ -82,10 +106,12 @@ export class PromptDispatcher {
         } finally {
             if (this.workspaceLocks.get(lockKey) === current) {
                 this.workspaceLocks.delete(lockKey);
+                logger.debug(`[PromptDispatcher] Lock RELEASED: ${lockKey} (total: ${this.workspaceLocks.size})`);
             }
             if (this.channelLocks.get(chKey) === current) {
                 this.channelLocks.delete(chKey);
             }
+            this.deps.onTaskComplete?.(req.channel, lockKey);
         }
     }
 }

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -14,7 +14,12 @@ export const RESPONSE_SELECTORS = {
      *  Reverse iteration (N-1→0) visits newest first; strict > keeps it. */
     RESPONSE_TEXT: `(() => {
         const panel = document.querySelector('.antigravity-agent-side-panel');
-        const scopes = [panel, document].filter(Boolean);
+        const rootScope = panel || document;
+
+        // Scope to the LAST assistant message turn to prevent cross-turn spillover.
+        const assistantTurns = rootScope.querySelectorAll('[data-message-author-role="assistant"]');
+        const lastTurn = assistantTurns.length > 0 ? assistantTurns[assistantTurns.length - 1] : null;
+        const scopes = lastTurn ? [lastTurn] : [rootScope];
 
         const selectors = [
             { sel: '.rendered-markdown', score: 10 },
@@ -777,8 +782,8 @@ export class ResponseMonitor {
                 this.baselineCardCount = bl.cardCount ?? 0;
             }
             logger.debug(`[ResponseMonitor] Artifact baseline: ${this.baselineNotifyCount} notify, ${this.baselineCardCount} cards`);
-        } catch {
-            // Best-effort; baseline stays at 0 (conservative: may still detect old artifacts)
+        } catch (e) {
+            logger.debug('[ResponseMonitor] Artifact baseline failed (best-effort):', e);
         }
 
         // Capture baselines in parallel (text + process logs + optional structured)
@@ -822,8 +827,8 @@ export class ResponseMonitor {
                         if (key) this.seenThinkingLogKeys.add(key);
                     }
                 }
-            } catch {
-                // structured baseline is best-effort
+            } catch (e) {
+                logger.debug('[ResponseMonitor] Structured baseline classification failed (best-effort):', e);
             }
         }
 
@@ -970,8 +975,8 @@ export class ResponseMonitor {
             this.seenProcessLogKeys.add(key);
             try {
                 this.onProcessLog?.(normalized.slice(0, 300));
-            } catch {
-                // callback error
+            } catch (e) {
+                logger.debug('[ResponseMonitor] onProcessLog callback error:', e);
             }
         }
     }
@@ -991,8 +996,8 @@ export class ResponseMonitor {
             logger.debug('[ResponseMonitor] Emitting thinking entry:', normalized.slice(0, 80));
             try {
                 this.onThinkingLog?.(normalized.slice(0, 2000));
-            } catch {
-                // callback error
+            } catch (e) {
+                logger.debug('[ResponseMonitor] onThinkingLog callback error:', e);
             }
         }
     }
@@ -1174,7 +1179,7 @@ export class ResponseMonitor {
                     await this.stop();
                     try {
                         await Promise.resolve(this.onTimeout?.(lastText));
-                    } catch { /* callback error */ }
+                    } catch (e) { logger.debug('[ResponseMonitor] onTimeout callback error:', e); }
                 }
                 return;
             }

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -14,12 +14,7 @@ export const RESPONSE_SELECTORS = {
      *  Reverse iteration (N-1→0) visits newest first; strict > keeps it. */
     RESPONSE_TEXT: `(() => {
         const panel = document.querySelector('.antigravity-agent-side-panel');
-        const rootScope = panel || document;
-
-        // Scope to the LAST assistant message turn to prevent cross-turn spillover.
-        const assistantTurns = rootScope.querySelectorAll('[data-message-author-role="assistant"]');
-        const lastTurn = assistantTurns.length > 0 ? assistantTurns[assistantTurns.length - 1] : null;
-        const scopes = lastTurn ? [lastTurn] : [rootScope];
+        const scopes = [panel, document].filter(Boolean);
 
         const selectors = [
             { sel: '.rendered-markdown', score: 10 },

--- a/src/ui/queueUi.ts
+++ b/src/ui/queueUi.ts
@@ -1,0 +1,27 @@
+import { InlineKeyboard } from 'grammy';
+import { escapeHtml } from '../utils/telegramFormatter';
+
+export const INTERRUPT_QUEUE_PREFIX = 'interrupt:queue:';
+export const INTERRUPT_NOW_PREFIX = 'interrupt:now:';
+export const INTERRUPT_DISCARD_PREFIX = 'interrupt:discard:';
+
+/**
+ * Build the interrupt keyboard shown when the user sends a message
+ * while Antigravity is still generating a response.
+ */
+export function buildInterruptUI(channelKey: string, prompt: string): { text: string; keyboard: InlineKeyboard } {
+    const preview = prompt.length > 80 ? prompt.slice(0, 80) + '…' : prompt;
+
+    const text =
+        `⏳ <b>Antigravity is working on a request.</b>\n\n` +
+        `<i>${escapeHtml(preview)}</i>\n\n` +
+        `Choose what to do with your message:`;
+
+    const keyboard = new InlineKeyboard()
+        .text('📥 Queue', `${INTERRUPT_QUEUE_PREFIX}${channelKey}`)
+        .text('⚡ Send now', `${INTERRUPT_NOW_PREFIX}${channelKey}`)
+        .row()
+        .text('🗑 Don\'t send', `${INTERRUPT_DISCARD_PREFIX}${channelKey}`);
+
+    return { text, keyboard };
+}

--- a/src/ui/queueUi.ts
+++ b/src/ui/queueUi.ts
@@ -5,12 +5,21 @@ export const INTERRUPT_QUEUE_PREFIX = 'interrupt:queue:';
 export const INTERRUPT_NOW_PREFIX = 'interrupt:now:';
 export const INTERRUPT_DISCARD_PREFIX = 'interrupt:discard:';
 
+/** Telegram callback_data max is 64 bytes. Truncate the key to fit the longest prefix. */
+const MAX_CB_KEY_LEN = 64 - INTERRUPT_DISCARD_PREFIX.length;
+
+/** Truncate a workspace key to fit within Telegram's 64-byte callback_data limit. */
+export function safeCallbackKey(key: string): string {
+    return key.length > MAX_CB_KEY_LEN ? key.substring(0, MAX_CB_KEY_LEN) : key;
+}
+
 /**
  * Build the interrupt keyboard shown when the user sends a message
  * while Antigravity is still generating a response.
  */
 export function buildInterruptUI(channelKey: string, prompt: string): { text: string; keyboard: InlineKeyboard } {
     const preview = prompt.length > 80 ? prompt.slice(0, 80) + '…' : prompt;
+    const cbKey = safeCallbackKey(channelKey);
 
     const text =
         `⏳ <b>Antigravity is working on a request.</b>\n\n` +
@@ -18,10 +27,10 @@ export function buildInterruptUI(channelKey: string, prompt: string): { text: st
         `Choose what to do with your message:`;
 
     const keyboard = new InlineKeyboard()
-        .text('📥 Queue', `${INTERRUPT_QUEUE_PREFIX}${channelKey}`)
-        .text('⚡ Send now', `${INTERRUPT_NOW_PREFIX}${channelKey}`)
+        .text('📥 Queue', `${INTERRUPT_QUEUE_PREFIX}${cbKey}`)
+        .text('⚡ Send now', `${INTERRUPT_NOW_PREFIX}${cbKey}`)
         .row()
-        .text('🗑 Don\'t send', `${INTERRUPT_DISCARD_PREFIX}${channelKey}`);
+        .text('🗑 Don\'t send', `${INTERRUPT_DISCARD_PREFIX}${cbKey}`);
 
     return { text, keyboard };
 }


### PR DESCRIPTION
## Problem

When a user sends a message while Antigravity is actively processing a previous prompt, the bot had no coherent strategy: it could silently queue, produce parallel output, or race on the workspace lock — all resulting in unpredictable UX.

## Solution

Implements a structured concurrency model with a user-facing interrupt keyboard.

### Architecture

**`interruptState.ts`** — Centralized singleton that tracks pending interrupt requests per workspace key. Decoupled from the bot handler to allow both the message handler and callback query handler to share state cleanly.

**`queueUi.ts`** — Builds the inline keyboard shown when the workspace is busy:
- **Queue** — adds the message to a FIFO queue; executes after the current task finishes
- **Stop & Send Now** — calls the existing `/stop` interrupt, then immediately dispatches the new prompt
- **Discard** — dismisses the message silently

**`promptDispatcher.ts`** changes:
- `isBusy(ch, cdp)` — checks the workspace lock synchronously
- `getWorkspaceKey(ch, cdp)` — exposes the lock key so `interruptState` and the bot handler use the same key
- `onTaskComplete` hook — fires after each task (success or error), triggering auto-queue dequeue

**`responseMonitor.ts`** changes:
- Empty `catch {}` blocks replaced with `logger.debug()` (same pattern as other modules)

**`bot/index.ts`** changes:
- Message handler checks `dispatcher.isBusy()` before dispatching; if busy, shows the interrupt keyboard instead of queuing blindly
- Grammy dispatch is now **fire-and-forget** — `promptDispatcher.send()` is not awaited in the handler, so Grammy's sequential middleware stack is unblocked and can process the next update (which might be the interrupt keyboard callback)
- Callback query handlers for `queue_prompt`, `send_now`, and `discard_prompt` actions
- Removed a dead unreachable duplicate handler block

## Testing

`npm run build` — clean. `npm test` (excluding DOM extractor suite, which is addressed in a separate PR) — 705 tests pass.
