### PR TITLE
fix: support Antigravity IDE v2 process name and chat input selector

### DIFF
--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -49,7 +49,7 @@ export interface UiSyncResult {
 /** Antigravity UI DOM selector constants */
 const SELECTORS = {
     /** Chat input box: textbox excluding xterm */
-    CHAT_INPUT: 'div[role="textbox"]:not(.xterm-helper-textarea)',
+    CHAT_INPUT: 'div[role="textbox"]:not(.xterm-helper-textarea), div[contenteditable="true"]:not(.xterm-helper-textarea)',
     /** Submit button search target tag */
     SUBMIT_BUTTON_CONTAINER: 'button',
     /** Submit icon SVG class candidates */

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -19,9 +19,9 @@ export function getAntigravityCliPath(): string {
     if (process.platform === 'win32') {
         const localAppData = process.env.LOCALAPPDATA;
         if (localAppData) {
-            return `${localAppData}\\Programs\\Antigravity\\Antigravity.exe`;
+            return `"${localAppData}\\Programs\\Antigravity IDE\\Antigravity IDE.exe"`;
         }
-        return 'Antigravity.exe'; // Fallback if LOCALAPPDATA is undefined
+        return '"Antigravity IDE.exe"'; // Fallback if LOCALAPPDATA is undefined
     }
 
     // Default for Linux or any unknown OS, assuming 'antigravity' is in the system PATH
@@ -45,7 +45,7 @@ export function extractProjectNameFromPath(workspacePath: string): string {
  * Used in user-facing messages (Telegram messages, CLI doctor, logs).
  */
 export function getAntigravityCdpHint(port: number = 9222): string {
-    const APP_NAME = 'Antigravity';
+    const APP_NAME = 'Antigravity IDE';
     switch (process.platform) {
         case 'darwin':
             return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;


### PR DESCRIPTION
## Description
This PR introduces support for **Antigravity IDE v2**, which includes breaking changes to both the executable paths and the DOM structure.

### What's Changed
1. **Process & Path Renaming (`src/utils/pathUtils.ts`)**: 
   - Updated the Windows installation fallback path from `\Programs\Antigravity\Antigravity.exe` to `\Programs\Antigravity IDE\Antigravity IDE.exe`.
   - Replaced the fallback command with `"Antigravity IDE.exe"` (enclosed in quotes to handle spaces).
   - Updated the `APP_NAME` constant for CDP hints.

2. **Chat Input Selector Update (`src/services/cdpService.ts`)**:
   - The chat input field's role attribute was changed from `role="textbox"` to `role="combobox"` in Antigravity v2. 
   - Updated `SELECTORS.CHAT_INPUT` to broadly target `div[contenteditable="true"]:not(.xterm-helper-textarea)` while preserving the legacy `role="textbox"` selector to ensure backward compatibility.

### Why this is needed
Without these changes, `remoat start` fails to locate the Antigravity v2 process properly and throws a `Chat input field not found` error during message injection, completely breaking the core functionality on the newest IDE version.

### Testing
- Tested locally on Windows with Antigravity IDE v2.
- Verified that `remoat open` can successfully launch/attach to the process.
- Verified that `remoat start` successfully connects and injects messages into the chat panel without errors.
