### PR TITLE
feat: support nested subdirectory navigation in /project command

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ From source, you can also use the bundled launcher scripts:
 
 > Launch Antigravity first, then start the bot. It connects automatically.
 
+### Headless Environments
+
+If you are running Remoat on a headless Linux server or container, Antigravity requires a virtual display server (such as Xvfb) to launch.
+
+1. **Configure a Virtual Display**: Ensure a display server is running. For example, start a virtual framebuffer on display `:99`:
+   ```bash
+   Xvfb :99 -screen 0 1024x768x16 &
+   ```
+2. **Export the Display Variable**: Make sure the environment variable is set so child processes launched by Remoat can access the virtual display:
+   ```bash
+   export DISPLAY=:99
+   ```
+3. **Launch**: Relaunch or start Remoat as usual.
+
 ### Forum Topics (optional)
 
 For multi-project workflows, Remoat supports Telegram Forum Topics — each project gets its own topic thread.
@@ -205,6 +219,9 @@ remoat --quiet      errors only
 | `/model [name]` | Switch the LLM model (e.g. `gemini-2.5-pro`, `claude-opus-4-6`) |
 | `/mode` | Switch execution mode (`fast`, `plan`) |
 | `/stop` | Force-stop a running Antigravity task |
+| `/allow` | Approve the current file edit or plan proceed request |
+| `/deny` | Deny the current file edit or plan proceed request |
+| `/close` | Terminate the active Antigravity workspace via CDP |
 | | |
 | `/template` | List registered prompt templates with execute buttons |
 | `/template_add <name> <prompt>` | Register a new prompt template |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remoat",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remoat",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1468,15 +1468,30 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             return;
         }
 
-        // Project page navigation
-        if (data.startsWith(`${PROJECT_PAGE_PREFIX}:`)) {
-            const page = parseProjectPageId(data);
-            if (!isNaN(page)) {
-                const workspaces = workspaceService.scanWorkspaces();
-                const { text, keyboard } = buildProjectListUI(workspaces, page);
-                try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed (expected for unmodified):', e); }
-            }
+        // Project folder navigation
+        if (data.startsWith('proj_nav:')) {
+            const nextPath = data.slice('proj_nav:'.length);
+            const workspaces = workspaceService.scanWorkspaces(nextPath);
+            const { text, keyboard } = buildProjectListUI(workspaces, 0, nextPath);
+            try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
             await ctx.answerCallbackQuery();
+            return;
+        }
+
+        // Project folder pagination
+        if (data.startsWith('proj_pg:')) {
+            const parts = data.slice('proj_pg:'.length).split(':');
+            const page = parseInt(parts[0], 10) || 0;
+            const nextPath = parts.slice(1).join(':');
+            const workspaces = workspaceService.scanWorkspaces(nextPath);
+            const { text, keyboard } = buildProjectListUI(workspaces, page, nextPath);
+            try { await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard }); } catch (e) { logger.debug('[editMsg] Telegram edit failed:', e); }
+            await ctx.answerCallbackQuery();
+            return;
+        }
+
+        if (data === 'proj_err') {
+            await ctx.answerCallbackQuery({ text: '⚠️ Directory path is too deep to navigate via Telegram buttons.', show_alert: true });
             return;
         }
 

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -422,9 +422,24 @@ export class CdpService extends EventEmitter {
             logger.debug(`  - title="${p.title}" url=${p.url}`);
         }
 
-        // 1. Title match (fast path)
-        const titleMatch = workbenchPages.find((t: any) => t.title?.includes(projectName));
+        // 1. Title match (fast path) — try each ancestor segment of the path
+        // For a nested path like /home/user/opencode/remoat, try segments in
+        // reverse order: ["remoat", "opencode", "user", ...]
+        const pathSegments = workspacePath.split(/[\/\\]/).filter(Boolean).reverse();
+        let titleMatch: any = null;
+        let matchedSegment = projectName;
+        for (const segment of pathSegments) {
+            const found = workbenchPages.find((t: any) =>
+                t.title?.toLowerCase().includes(segment.toLowerCase())
+            );
+            if (found) {
+                titleMatch = found;
+                matchedSegment = segment;
+                break;
+            }
+        }
         if (titleMatch) {
+            logger.debug(`[CdpService] Title matched via segment "${matchedSegment}" for project "${projectName}"`);
             return this.connectToPage(titleMatch, projectName);
         }
 

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -565,12 +565,18 @@ export class CdpService extends EventEmitter {
                 const normalizedProject = projectName.toLowerCase();
                 const normalizedWorkspace = workspacePath.toLowerCase();
 
+                const workspaceSegments = normalizedWorkspace.split(/[/\\]/).filter(Boolean);
+                const projectSegments = normalizedProject.split(/[/\\]/).filter(Boolean);
+
                 if (
                     normalizedDetected.includes(normalizedProject) ||
-                    normalizedDetected.includes(normalizedWorkspace)
+                    normalizedDetected.includes(normalizedWorkspace) ||
+                    (normalizedDetected.startsWith('/') && normalizedWorkspace.startsWith(normalizedDetected)) ||
+                    workspaceSegments.includes(normalizedDetected) ||
+                    projectSegments.includes(normalizedDetected)
                 ) {
                     this.currentWorkspaceName = projectName;
-                    logger.debug(`[CdpService] Folder path match success: "${projectName}"`);
+                    logger.debug(`[CdpService] Folder path match success: "${projectName}" (detected="${detectedValue}")`);
                     return true;
                 }
             }

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -634,7 +634,7 @@ export class CdpService extends EventEmitter {
             );
         }
 
-        const launchArgs = [`--remote-debugging-port=${cdpPort}`, '--new-window', workspacePath];
+        const launchArgs = [`--remote-debugging-port=${cdpPort}`, '--reuse-window', workspacePath];
         logger.debug(`[CdpService] Launching Antigravity: ${antigravityCli} ${launchArgs.join(' ')}`);
         try {
             await this.runCommand(antigravityCli, launchArgs);

--- a/src/services/workspaceService.ts
+++ b/src/services/workspaceService.ts
@@ -22,16 +22,21 @@ export class WorkspaceService {
     }
 
     /**
-     * Return a list of subdirectories in the base directory
+     * Return a list of subdirectories in the specified relative path
      */
-    public scanWorkspaces(): string[] {
+    public scanWorkspaces(relativePath: string = ''): string[] {
         this.ensureBaseDir();
+        const absolutePath = this.validatePath(relativePath);
 
-        const entries = fs.readdirSync(this.baseDir, { withFileTypes: true });
-        return entries
-            .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
-            .map((entry) => entry.name)
-            .sort();
+        try {
+            const entries = fs.readdirSync(absolutePath, { withFileTypes: true });
+            return entries
+                .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules')
+                .map((entry) => entry.name)
+                .sort();
+        } catch {
+            return [];
+        }
     }
 
     /**

--- a/src/ui/projectListUi.ts
+++ b/src/ui/projectListUi.ts
@@ -23,46 +23,82 @@ export function isProjectSelectId(customId: string): boolean {
 export function buildProjectListUI(
     workspaces: string[],
     page: number = 0,
+    currentPath: string = '',
 ): { text: string; keyboard: InlineKeyboard } {
     const totalPages = Math.max(1, Math.ceil(workspaces.length / ITEMS_PER_PAGE));
     const safePage = Math.max(0, Math.min(page, totalPages - 1));
 
+    const pathHeader = currentPath ? `📁 <b>/${escapeHtml(currentPath)}</b>` : `📁 <b>Root</b>`;
+    let text = `<b>📁 Project Selection</b>\n\n` +
+        `Current path: ${pathHeader}\n` +
+        `Select a subdirectory to navigate into it, or click <b>Select Current</b> to bind this directory.\n\n`;
+
     if (workspaces.length === 0) {
-        return {
-            text: `<b>📁 Projects</b>\n\n${t('No projects found.')}`,
-            keyboard: new InlineKeyboard(),
-        };
-    }
+        text += `<i>(No subdirectories found here)</i>`;
+    } else {
+        const start = safePage * ITEMS_PER_PAGE;
+        const end = Math.min(start + ITEMS_PER_PAGE, workspaces.length);
+        const pageItems = workspaces.slice(start, end);
 
-    const start = safePage * ITEMS_PER_PAGE;
-    const end = Math.min(start + ITEMS_PER_PAGE, workspaces.length);
-    const pageItems = workspaces.slice(start, end);
+        const lines = pageItems.map((ws, i) =>
+            `${start + i + 1}. 📁 ${escapeHtml(ws)}`,
+        );
+        text += lines.join('\n');
 
-    const lines = pageItems.map((ws, i) =>
-        `${start + i + 1}. ${escapeHtml(ws)}`,
-    );
-
-    let text = `<b>📁 Projects</b>\n\n` +
-        t('Select a project to auto-create a topic and session') + `\n\n` +
-        lines.join('\n');
-
-    if (totalPages > 1) {
-        text += `\n\n<i>Page ${safePage + 1} / ${totalPages} (${workspaces.length} projects total)</i>`;
+        if (totalPages > 1) {
+            text += `\n\n<i>Page ${safePage + 1} / ${totalPages} (${workspaces.length} folders total)</i>`;
+        }
     }
 
     const keyboard = new InlineKeyboard();
 
-    for (const ws of pageItems) {
-        const label = ws.length > 40 ? ws.substring(0, 37) + '...' : ws;
-        keyboard.text(label, `${PROJECT_SELECT_ID}:${ws}`).row();
+    // 1. Select Current Directory button (if currentPath is not empty)
+    if (currentPath) {
+        keyboard.text(`✅ Select Current: /${currentPath.length > 20 ? '...' + currentPath.slice(-17) : currentPath}`, `${PROJECT_SELECT_ID}:${currentPath}`).row();
+    }
+
+    // 2. Navigation List
+    if (workspaces.length > 0) {
+        const start = safePage * ITEMS_PER_PAGE;
+        const end = Math.min(start + ITEMS_PER_PAGE, workspaces.length);
+        const pageItems = workspaces.slice(start, end);
+
+        for (const ws of pageItems) {
+            const nextPath = currentPath ? `${currentPath}/${ws}` : ws;
+            const callbackData = `proj_nav:${nextPath}`;
+            if (callbackData.length <= 64) {
+                const label = `📁 ${ws.length > 35 ? ws.substring(0, 32) + '...' : ws}`;
+                keyboard.text(label, callbackData).row();
+            } else {
+                const label = `📁 [Too deep] ${ws.substring(0, 15)}`;
+                keyboard.text(label, `proj_err`).row();
+            }
+        }
+    }
+
+    // 3. Pagination & Back buttons
+    const navRow: { text: string; data: string }[] = [];
+
+    // Parent folder button
+    if (currentPath) {
+        const parts = currentPath.split('/');
+        parts.pop();
+        const parentPath = parts.join('/');
+        navRow.push({ text: '⬆️ Up', data: `proj_nav:${parentPath}` });
     }
 
     if (totalPages > 1) {
         if (safePage > 0) {
-            keyboard.text('◀ Prev', `${PROJECT_PAGE_PREFIX}:${safePage - 1}`);
+            navRow.push({ text: '◀ Prev', data: `proj_pg:${safePage - 1}:${currentPath}` });
         }
         if (safePage < totalPages - 1) {
-            keyboard.text('Next ▶', `${PROJECT_PAGE_PREFIX}:${safePage + 1}`);
+            navRow.push({ text: 'Next ▶', data: `proj_pg:${safePage + 1}:${currentPath}` });
+        }
+    }
+
+    if (navRow.length > 0) {
+        for (const btn of navRow) {
+            keyboard.text(btn.text, btn.data);
         }
         keyboard.row();
     }


### PR DESCRIPTION
This pull request adds support for nested subdirectory navigation in the `/project` command.

### Changes:
- Scans workspaces recursively and allows navigation through folders directly in the Telegram UI.
- Adds pagination support for deeply nested directories.
- Reuses the existing IDE window instead of launching a new window when switching project paths.
- Resolves workspace matches when the open workspace is a parent directory of the selected project.